### PR TITLE
fix: ajustar destinatarios plan de auditoria

### DIFF
--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -22,12 +22,22 @@ export const environment = {
 
   PLANTILLA_CARGUE_MASIVO: "8e51a50e-9b80-4c93-a917-20b958fd3d2b",
 
-  // TODO: Replace with dependency and chief emails. Current are for testing purposes only.
+  /**
+   * Destination emails for audit plan notifications.
+   * TODO: Add with dependency and chief emails.
+   */
   NOTIFICACION_PLAN_AUDITORIA_DESTINATARIOS: {
+    /** Direct recipient emails go here */
     ToAddresses: [
-      "cjgonzalezp@udistrital.edu.co",
-      "hegranadosl@udistrital.edu.co",
-      "ndsabogalv@udistrital.edu.co",
+      // "send.to@ejemplo.com"
+    ],
+    /** Carbon copy recipient emails go here */
+    CcAddresses: [
+      // "copy.to@ejemplo.com"
+    ],
+    /** Blind carbon copy recipient emails go here */
+    BccAddresses: [
+      // "blind.copy.to@ejemplo.com"
     ]
   },
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -24,12 +24,22 @@ export const environment = {
 
   PLANTILLA_CARGUE_MASIVO: "8e51a50e-9b80-4c93-a917-20b958fd3d2b",
 
-  // TODO: Replace with dependency and chief emails. Current are for testing purposes only.
+  /**
+   * Destination emails for audit plan notifications.
+   * TODO: Add with dependency and chief emails.
+   */
   NOTIFICACION_PLAN_AUDITORIA_DESTINATARIOS: {
+    /** Direct recipient emails go here */
     ToAddresses: [
-      "cjgonzalezp@udistrital.edu.co",
-      "hegranadosl@udistrital.edu.co",
-      "ndsabogalv@udistrital.edu.co",
+      // "send.to@ejemplo.com"
+    ],
+    /** Carbon copy recipient emails go here */
+    CcAddresses: [
+      // "copy.to@ejemplo.com"
+    ],
+    /** Blind carbon copy recipient emails go here */
+    BccAddresses: [
+      // "blind.copy.to@ejemplo.com"
     ]
   },
 


### PR DESCRIPTION
This pull request updates the configuration for audit plan notification emails in both the development and production environment files. The main change is the removal of hardcoded test email addresses and the addition of clear placeholders and documentation for where to add the actual recipient, CC, and BCC addresses.

Fixes: https://github.com/udistrital/sisifo_documentacion/issues/439

Configuration improvements for notification emails:

* Removed hardcoded test email addresses from `NOTIFICACION_PLAN_AUDITORIA_DESTINATARIOS` and replaced them with commented placeholders for To, CC, and BCC fields in both `environment.development.ts` and `environment.ts`. [[1]](diffhunk://#diff-a8781811a71ccc5e6e8919aa7054cf3a9c66d8624b4687cb9029aa12a5b93049L25-R40) [[2]](diffhunk://#diff-d897f7d114ca657c43905bff9a6ee17e53e2d1ccc172b7c258a54183653a691aL27-R42)
* Added descriptive comments to clarify where to add direct, carbon copy, and blind carbon copy recipient emails for audit plan notifications. [[1]](diffhunk://#diff-a8781811a71ccc5e6e8919aa7054cf3a9c66d8624b4687cb9029aa12a5b93049L25-R40) [[2]](diffhunk://#diff-d897f7d114ca657c43905bff9a6ee17e53e2d1ccc172b7c258a54183653a691aL27-R42)…_documentacion#439