### PR TITLE
fix: Renderizar PAA actualizado con auditorías padre

### DIFF
--- a/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan.auditoria.utils.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan.auditoria.utils.ts
@@ -213,7 +213,7 @@ export class DocumentoUtils {
           nombre: "Actualizar Documento",
           accion: () => this.handleActualizarDocumento(
             planId,
-            `plantilla/${planId}?conEspeciales=true`,
+            `plantilla/${planId}?auditoria-padre=true&conEspeciales=true`,
             environment.TIPO_DOCUMENTO_PARAMETROS.PLAN_ANUAL_AUDITORIA_ACTUALIZADO,
             refreshCallbacks?.[REFRESHABLES.FORMATO_PAA_ACTUALIZADO],
           ),


### PR DESCRIPTION
This pull request makes a minor update to the URL used when updating a document in the `DocumentoUtils` class. The change ensures that the request includes the `auditoria-padre=true` parameter, which ensures that `auditoria-padre` is used for rendering instead of child `auditoria`.

- Answers to udistrital/sisifo_documentacion#593

## Changes

- Updated the URL in the `handleActualizarDocumento` method to include the `auditoria-padre=true` parameter, ensuring proper handling of parent audit documents.