### PR TITLE
feat: Añadir subtitulo de auditoría

### DIFF
--- a/src/app/modules/ejecucion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.utilidades.ts
+++ b/src/app/modules/ejecucion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.utilidades.ts
@@ -1,3 +1,5 @@
+import { tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
+
 export const colocacionesContructorTabla = [
   {
     columnDef: "numero",
@@ -14,7 +16,7 @@ export const colocacionesContructorTabla = [
   {
     columnDef: "auditoria",
     header: "Auditoria",
-    cell: (auditoria: any) => auditoria.titulo,
+    cell: (auditoria: any) => tituloYSubtituloAuditoria(auditoria),
     sortable: true,
   },
   {

--- a/src/app/modules/ejecucion/components/seguimiento-informes/tabla-segumiento/tabla-seguimientos.utilidades.ts
+++ b/src/app/modules/ejecucion/components/seguimiento-informes/tabla-segumiento/tabla-seguimientos.utilidades.ts
@@ -1,3 +1,5 @@
+import { tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
+
 export const seguimientosConstructorTabla = [
   {
     columnDef: "numero",
@@ -14,7 +16,7 @@ export const seguimientosConstructorTabla = [
   {
     columnDef: "auditoria",
     header: "Auditoría",
-    cell: (seguimiento: any) => seguimiento.titulo || seguimiento.auditoria_nombre,
+    cell: (seguimiento: any) => tituloYSubtituloAuditoria(seguimiento),
     sortable: true,
   },
   {

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -13,7 +13,7 @@ import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditori
 import { MatDialog } from "@angular/material/dialog";
 import { ModalVerDocumentoComponent } from "src/app/shared/elements/components/dialogs/modal-ver-documento/modal-ver-documento.component";
 import { Router } from "@angular/router";
-import { Auditoria } from "src/app/shared/data/models/auditoria";
+import { Auditoria, tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
 import { AlertService } from "src/app/shared/services/alert.service";
 import { environment } from "src/environments/environment";
 import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
@@ -275,7 +275,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
           { nombre: "Carta de representación", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION },
           { nombre: "Compromiso ético", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.COMPROMISO_ETICO },
         ],
-        titulo: `${auditoria.titulo}`,
+        titulo: `${tituloYSubtituloAuditoria(auditoria)}`,
         descripcion: `Documentos asociados a la auditoría`
       },
       autoFocus: false,

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.utilidades.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.utilidades.ts
@@ -1,3 +1,5 @@
+import { tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
+
 export const colocacionesContructorTabla = [
   {
     columnDef: "numero",
@@ -14,7 +16,7 @@ export const colocacionesContructorTabla = [
   {
     columnDef: "auditoria",
     header: "Auditoria",
-    cell: (auditoria: any) => auditoria.titulo,
+    cell: (auditoria: any) => tituloYSubtituloAuditoria(auditoria),
     sortable: true,
   },
   {

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.utilidades.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.utilidades.ts
@@ -1,3 +1,5 @@
+import { tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
+
 export const colocacionesContructorTabla = [
   {
     columnDef: "numero",
@@ -14,7 +16,7 @@ export const colocacionesContructorTabla = [
   {
     columnDef: "auditoria",
     header: "Auditoria",
-    cell: (auditoria: any) => auditoria.titulo,
+    cell: (auditoria: any) => tituloYSubtituloAuditoria(auditoria),
     sortable: true,
   },
   {

--- a/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.html
+++ b/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.html
@@ -11,22 +11,33 @@
       <div class="row">
         <form [formGroup]="form">
           <div class="row mt-2">
-            <div class="col-12 col-md-6 col-xl-4">
+            <div class="col-12 col-md-12 col-xl-8">
               <div class="fondo-acento-50 d-flex justify-content-center my-3">
                 <b>Auditoría</b>
               </div>
-              <mat-form-field class="col-12" appearance="outline">
-                <mat-label>Nombre de Auditoría</mat-label>
-                <mat-icon matPrefix color="primary">developer_board</mat-icon>
-                <input
-                  matInput
-                  placeholder="Título de la Auditoría"
-                  formControlName="tituloAuditoria"
-                  readonly
-                />
-              </mat-form-field>
+              <div class="row">
+                <mat-form-field class="col-6" appearance="outline">
+                  <mat-label>Nombre de Auditoría</mat-label>
+                  <mat-icon matPrefix color="primary">developer_board</mat-icon>
+                  <input
+                    matInput
+                    placeholder="Título de la Auditoría"
+                    formControlName="tituloAuditoria"
+                    readonly
+                  />
+                </mat-form-field>
+                <mat-form-field class="col-6" appearance="outline">
+                  <mat-label>Nombre complementario</mat-label>
+                  <mat-icon matPrefix color="primary">developer_board</mat-icon>
+                  <input
+                    matInput
+                    placeholder="Subtítulo de la Auditoría"
+                    formControlName="subtituloAuditoria"
+                  />
+                </mat-form-field>
+              </div>
             </div>
-            <div class="col-12 col-md-6 col-xl-4">
+            <div class="col-12 col-md-12 col-xl-4">
               <div class="fondo-acento-50 d-flex justify-content-center my-3">
                 <b>Tipo de evaluación</b>
               </div>
@@ -41,7 +52,7 @@
                 />
               </mat-form-field>
             </div>
-            <div class="col-12 col-md-6 col-xl-4">
+            <div class="col-12 col-md-12 col-xl-12">
               <div class="fondo-acento-50 d-flex justify-content-center my-3">
                 <b>Cronograma de actividades</b>
               </div>

--- a/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.ts
+++ b/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.ts
@@ -50,6 +50,7 @@ export class ModalAgregarAuditorComponent implements OnInit {
     });
     this.form = this.fb.group({
       tituloAuditoria: [this.data.auditoria?.titulo || ""],
+      subtituloAuditoria: [this.data.auditoria?.subtitulo || ""],
       tipoEvaluacion: [this.data.auditoria?.tipo_evaluacion_nombre || []],
       cronogramaActividades: [this.data.auditoria?.cronograma_nombre || []],
       auditoresSeleccionados: this.auditoresSeleccionados,
@@ -258,6 +259,7 @@ export class ModalAgregarAuditorComponent implements OnInit {
             });
             const formData = {
               titulo: this.form.value.tituloAuditoria,
+              subtitulo: this.form.value.subtituloAuditoria,
               tipo_evaluacion_id: this.data.auditoria?.tipo_evaluacion_id,
               cronograma_id: this.data.auditoria?.cronograma_id,
               //auditores: auditoresSeleccionados

--- a/src/app/modules/programacion/components/asignar-auditorias/tabla-consulta-auditorias/tabla-consulta-auditorias.utilidades.ts
+++ b/src/app/modules/programacion/components/asignar-auditorias/tabla-consulta-auditorias/tabla-consulta-auditorias.utilidades.ts
@@ -1,3 +1,5 @@
+import { tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
+
 export const colocacionesContructorTabla = [
   {
     columnDef: "numero",
@@ -8,7 +10,7 @@ export const colocacionesContructorTabla = [
   {
     columnDef: "auditoria",
     header: "Auditoria",
-    cell: (auditoria: any) => auditoria.titulo,
+    cell: (auditoria: any) => tituloYSubtituloAuditoria(auditoria),
     sortable: true,
   },
   {

--- a/src/app/shared/data/models/auditoria-auditor.ts
+++ b/src/app/shared/data/models/auditoria-auditor.ts
@@ -2,6 +2,7 @@ export class Auditoria {
     _id!: string;
     activo!: boolean;
     titulo!: string;
+    subtitulo!: string;
     tipo_evaluacion_nombre!: string[];
     tipo_evaluacion_id!: number[];
     cronograma_nombre!: string[];

--- a/src/app/shared/data/models/auditoria.ts
+++ b/src/app/shared/data/models/auditoria.ts
@@ -2,6 +2,7 @@ export interface Auditoria {
   _id: string;
   plan_auditoria_id: string;
   titulo: string;
+  subtitulo: string;
   tipo_evaluacion_id: number;
   cronograma_id: number[];
   estado_id: number;
@@ -40,3 +41,7 @@ export interface Auditoria {
   correo_dependencia?: string;
   correo_complementario?: string;
 }
+
+export function tituloYSubtituloAuditoria(auditoria: Auditoria): string {
+  return auditoria.subtitulo ? `${auditoria.titulo} - ${auditoria.subtitulo}` : auditoria.titulo;
+};


### PR DESCRIPTION
This pull request enhances how audit information is displayed and managed throughout the application by introducing support for a complementary subtitle (`subtitulo`) for each audit. The changes ensure that both the title and subtitle are shown together where appropriate, and update forms and data models to handle this new field.

- Answers to udistrital/sisifo_documentacion#629

**Audit title and subtitle display improvements:**

* Added a new utility function `tituloYSubtituloAuditoria` to `src/app/shared/data/models/auditoria.ts`, which concatenates an audit's title and subtitle for display. This function is now used in all relevant table utilities to show both fields together instead of just the title. [[1]](diffhunk://#diff-94f18c079ba5e8475258b61008fde3398917faf3be414350108eb818fe025462R44-R47) [[2]](diffhunk://#diff-119449ed5f452c15d30124758ac48a2c81714127c7929efce8c58a79387b9761R1-R2) [[3]](diffhunk://#diff-119449ed5f452c15d30124758ac48a2c81714127c7929efce8c58a79387b9761L17-R19) [[4]](diffhunk://#diff-3ce48a6899f9b62d7357c78097d0a0de9ae50c249b53ae19830aa9e166c264a5R1-R2) [[5]](diffhunk://#diff-3ce48a6899f9b62d7357c78097d0a0de9ae50c249b53ae19830aa9e166c264a5L17-R19) [[6]](diffhunk://#diff-451f2e586939867914336b68c6d2fdb844e321fda853e448e0924339210817ceR1-R2) [[7]](diffhunk://#diff-451f2e586939867914336b68c6d2fdb844e321fda853e448e0924339210817ceL17-R19) [[8]](diffhunk://#diff-217816b4ea41a80885139a2db6bb00718ff991e7cee76855b2274b759929f641R1-R2) [[9]](diffhunk://#diff-217816b4ea41a80885139a2db6bb00718ff991e7cee76855b2274b759929f641L17-R19) [[10]](diffhunk://#diff-68674b636a6013f1f1ac1b193cdeff7c8c850b857c5df963fc635aa2b73ed894R1-R2) [[11]](diffhunk://#diff-68674b636a6013f1f1ac1b193cdeff7c8c850b857c5df963fc635aa2b73ed894L11-R13) [[12]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L16-R16) [[13]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L278-R278)

**Data model updates:**

* Added the `subtitulo` property to both `Auditoria` interface in `auditoria.ts` and `Auditoria` class in `auditoria-auditor.ts` to support the new subtitle field in the data model. [[1]](diffhunk://#diff-94f18c079ba5e8475258b61008fde3398917faf3be414350108eb818fe025462R5) [[2]](diffhunk://#diff-f31c2e8f4c0d78ad471af05e41b728e77923f1cc8ac482a14e1ea3d19cc62a4eR5)

**Form and modal enhancements:**

* Updated the "Agregar Auditor" modal form to include a new input for the audit subtitle (`subtituloAuditoria`), ensuring that users can view and edit both the title and subtitle. The form layout was adjusted for better usability, and the subtitle is now included when submitting form data. [[1]](diffhunk://#diff-f230d1ed49009418e66f2b39cb682a42e957c78a9f8d158d7271fc78057bc41cL14-R19) [[2]](diffhunk://#diff-f230d1ed49009418e66f2b39cb682a42e957c78a9f8d158d7271fc78057bc41cR29-R40) [[3]](diffhunk://#diff-f230d1ed49009418e66f2b39cb682a42e957c78a9f8d158d7271fc78057bc41cL44-R55) [[4]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR53) [[5]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR262)

These changes collectively improve the clarity and completeness of audit information presented to users and standardize how audit titles and subtitles are handled across the application.