### PR TITLE
feat: maquetación de modales e integración de hallazgos (Plan de Mejoramiento) #661 y #668

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -31,7 +31,7 @@ const routes: Routes = [
   },
   {
     path: 'plan-mejoramiento',
-    canActivate: [AuthGuard], 
+    //canActivate: [AuthGuard], 
     loadChildren: () => import('./modules/plan-mejoramiento/plan-mejoramiento.module').then(
       (m) => m.PlanesModule)
   },

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component.css
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component.css
@@ -1,0 +1,117 @@
+.seccion-header {
+  background-color: var(--md-accent-50);
+  color: var(--md-accent-900);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.seccion-header b {
+  font-weight: 500;
+}
+
+.auditor-readonly {
+  padding: 15px;
+  color: var(--md-accent-900);
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  border-left: 6px solid var(--md-primary-500);
+  margin-bottom: 8px;
+  display: flex;
+  align-items: flex-start; 
+}
+
+.auditor-readonly .icon-chip {
+  flex-shrink: 0;          
+  width: 20px;
+  height: 20px;
+  font-size: 20px;
+  margin-right: 8px;
+  margin-top: 1px;         
+  color: var(--md-primary-500);
+}
+
+.auditor-tag {
+  border: 1px solid var(--md-accent-600);
+  padding: 5px;
+  padding-right: 10px;
+  border-radius: 10px;
+  font-size: 12px;
+  margin-left: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.auditor-tag mat-icon {
+  width: 15px;
+  height: 15px;
+  font-size: 15px;
+  margin-right: 3px;
+  margin-bottom: -4px;
+  color: var(--md-accent-600);
+}
+
+.info-guardar {
+  padding: 15px;
+  color: var(--md-accent-900);
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  border-left: 6px solid var(--md-primary-500);
+}
+
+.info-guardar mat-icon {
+  width: 15px;
+  height: 15px;
+  font-size: 15px;
+  margin-right: 8px;
+  color: var(--md-primary-500);
+}
+
+.info-guardar p {
+  font-size: 13px;
+  color: var(--md-accent-900);
+  margin: 0;
+}
+
+.btn-cerrar {
+  border: 1px solid var(--md-primary-500) !important;
+}
+
+.btn-agregar {
+  white-space: nowrap;
+  height: 40px;
+}
+
+@media (max-width: 768px) {
+  .auditor-tag {
+    font-size: 9.5px;
+  }
+}
+
+.tabla-auditores-readonly {
+  border-collapse: collapse;
+  font-size: 13px;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.tabla-auditores-readonly td {
+  padding: 8px 12px;
+  text-align: left;
+  border: 1px solid #e8e8e8;
+  width: 100%;
+  word-break: break-word;
+}
+
+.tabla-auditores-readonly tbody tr:nth-child(even) {
+  background-color: var(--md-accent-50);
+}
+
+.tabla-auditores-readonly .icon-chip {
+  width: 16px;
+  height: 16px;
+  font-size: 16px;
+  vertical-align: middle;
+  margin-right: 4px;
+  color: var(--md-primary-500);
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component.html
@@ -1,0 +1,149 @@
+<plantilla-modal
+  [icono]="'edit'"
+  [titulo]="'Asignar Auditor(es)'"
+  [descripcion]="subtituloModal"
+  [contenido]="contenidoDeModal"
+  [footer]="footerDeModal"
+></plantilla-modal>
+
+<ng-template #contenidoDeModal>
+  <div class="row mt-3">
+
+    <!-- Fila 1: Auditoría y Tipo de Evaluación — se muestran de inmediato -->
+    <div class="col-12 mb-3">
+      <div class="row mx-0">
+        <div class="col-6 pe-2">
+          <div class="seccion-header text-center mb-2">
+            <b>Auditoría</b>
+          </div>
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>Nombre de la auditoría</mat-label>
+            <input matInput [value]="data.auditoria?.titulo || ''" readonly />
+          </mat-form-field>
+        </div>
+        <div class="col-6 ps-2">
+          <div class="seccion-header text-center mb-2">
+            <b>Tipo de Evaluación</b>
+          </div>
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>Tipo de evaluación</mat-label>
+            <input matInput [value]="data.auditoria?.tipo_evaluacion_nombre || ''" readonly />
+          </mat-form-field>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fila 2: Cronograma de actividades — se muestra de inmediato -->
+    <div class="col-12 mb-3">
+      <div class="seccion-header text-center mb-2">
+        <b>Cronograma de actividades</b>
+      </div>
+      <mat-form-field appearance="outline" class="col-12">
+        <mat-label>Cronograma de actividades</mat-label>
+        <input matInput [value]="cronogramaTexto" readonly />
+      </mat-form-field>
+    </div>
+
+    <!-- Fila 3: Auditores Responsables Auditoría — se muestran de inmediato (solo lectura) -->
+    <div class="col-12 mb-3">
+      <p class="mb-2"><b>Auditor(es) Responsables Auditoría</b></p>
+      <table class="tabla-auditores-readonly w-100">
+        <tbody>
+          <tr *ngFor="let auditor of auditoresAuditoria">
+            <td>
+              <mat-icon class="icon-chip">person</mat-icon>
+              {{ auditor.nombre }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Fila 4: Auditores Responsables Plan (editable) -->
+    <div class="col-12 mb-2">
+      <p class="mb-2">
+        <b>Auditor(es) Responsables Plan<span class="text-danger">*</span></b>
+      </p>
+
+      <!-- Lista de auditores del plan ya agregados -->
+      <div
+        *ngFor="let auditor of auditoresPlan; let i = index"
+        class="fondo-chip d-flex align-items-center justify-content-between mb-2"
+      >
+        <div class="d-flex align-items-center">
+          <mat-icon class="icon-chip">person</mat-icon>
+          <span>{{ auditor.nombre }}</span>
+          <span class="auditor-tag">
+            <mat-icon>badge</mat-icon>
+            Auditor {{ i + 1 }}
+          </span>
+        </div>
+        <button
+          mat-icon-button
+          color="warn"
+          (click)="eliminarAuditorPlan(i)"
+          matTooltip="Eliminar auditor del plan"
+        >
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+
+      <!-- Selector: spinner solo aquí mientras carga, el resto del modal ya es visible -->
+      <div class="d-flex align-items-center mt-2 gap-2">
+        <mat-form-field appearance="outline" class="flex-grow-1">
+          <mat-label>Seleccione un auditor</mat-label>
+          <mat-icon color="primary" matPrefix>person_search</mat-icon>
+          <mat-select [(ngModel)]="auditorSeleccionado" [disabled]="cargando">
+            <mat-option *ngIf="cargando" disabled>
+              <mat-spinner diameter="20" class="spinner-inline"></mat-spinner>
+              Cargando auditores...
+            </mat-option>
+            <mat-option
+              *ngFor="let auditor of auditoresDisponibles"
+              [value]="auditor"
+            >
+              {{ auditor.nombre }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button
+          mat-raised-button
+          color="primary"
+          class="btn-agregar mb-4"
+          (click)="agregarAuditorPlan()"
+          [disabled]="!auditorSeleccionado || cargando"
+        >
+          <mat-icon>add</mat-icon> Agregar Auditor
+        </button>
+      </div>
+
+      <!-- Mensaje informativo -->
+      <div class="info-guardar d-flex align-items-center my-2">
+        <mat-icon>info</mat-icon>
+        <p class="mb-0 ms-2">¿Guardar cambios?</p>
+      </div>
+    </div>
+
+  </div>
+</ng-template>
+
+<ng-template #footerDeModal>
+  <div class="d-flex justify-content-end gap-2 mb-3">
+    <button
+      mat-stroked-button
+      color="warn"
+      class="btn-cerrar"
+      [mat-dialog-close]
+    >
+      <mat-icon>close</mat-icon> No, cerrar
+    </button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="guardarYCerrar()"
+      [disabled]="cargando"
+    >
+      <mat-icon>save</mat-icon> Sí, guardar y cerrar
+    </button>
+  </div>
+</ng-template>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component.ts
@@ -1,0 +1,244 @@
+import { Component, Inject, OnInit } from "@angular/core";
+import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { forkJoin, of } from "rxjs";
+import { catchError } from "rxjs/operators";
+import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
+import { AlertService } from "src/app/shared/services/alert.service";
+import { AutenticacionMidService } from "src/app/core/services/autenticacion-mid.service";
+
+export interface DatosModalAsignacionAuditores {
+  auditoria: any;
+  usuarioId: number;
+  role: string;
+}
+
+@Component({
+  selector: "app-modal-asignacion-auditores",
+  templateUrl: "./modal-asignacion-auditores.component.html",
+  styleUrls: ["./modal-asignacion-auditores.component.css"],
+})
+export class ModalAsignacionAuditoresComponent implements OnInit {
+  /** Texto de descripción del modal (subtítulo con nombre de la auditoría) */
+  subtituloModal: string = "";
+
+  /** Texto formateado del cronograma (fechas inicio/fin) */
+  cronogramaTexto: string = "";
+
+  /** Nombres de los auditores ya asignados a la auditoría (solo lectura) */
+  auditoresAuditoriaTexto: string = "";
+  auditoresAuditoria: { nombre: string }[] = [];
+
+  /** Auditores asignados al plan de mejoramiento (editables) */
+  auditoresPlan: { id: string; nombre: string }[] = [];
+
+  /** Lista de auditores disponibles para seleccionar en el dropdown */
+  auditoresDisponibles: { id: string; nombre: string }[] = [];
+
+  /** Auditor actualmente seleccionado en el dropdown */
+  auditorSeleccionado: { id: string; nombre: string } | null = null;
+
+  /** IDs de los registros auditoria-auditor del plan ya existentes (para DELETE) */
+  private registrosAuditoresPlan: {
+    registroId: string;
+    auditorId: string;
+    nombre: string;
+  }[] = [];
+
+  /** Auditores marcados para eliminar al guardar */
+  private auditoresAEliminar: string[] = [];
+
+  cargando: boolean = false;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: DatosModalAsignacionAuditores,
+    private readonly dialogRef: MatDialogRef<ModalAsignacionAuditoresComponent>,
+    private readonly planAuditoriaService: PlanAnualAuditoriaService,
+    private readonly alertService: AlertService,
+    private readonly autenticacionMidService: AutenticacionMidService
+  ) {}
+
+  ngOnInit(): void {
+    // Datos estáticos: se resuelven síncronamente, el template los tiene de inmediato
+    this.inicializarDatos();
+    this.cargarAuditoresAuditoria();
+    setTimeout(() => this.cargarDatosEnParalelo(), 0);
+  }
+
+  private inicializarDatos(): void {
+    const auditoria = this.data.auditoria;
+    this.subtituloModal = auditoria?.titulo ?? "";
+
+    const inicio = auditoria?.fecha_inicio
+      ? new Date(auditoria.fecha_inicio).toLocaleDateString("es-CO")
+      : "";
+    const fin = auditoria?.fecha_fin
+      ? new Date(auditoria.fecha_fin).toLocaleDateString("es-CO")
+      : "";
+    this.cronogramaTexto =
+      inicio && fin ? `${inicio} — ${fin}` : "Sin cronograma registrado";
+  }
+
+  /** Carga los auditores ya asignados a la auditoría (campo read-only) */
+  private cargarAuditoresAuditoria(): void {
+    const auditores = this.data.auditoria?.auditores ?? [];
+
+    this.auditoresAuditoria = auditores.map((a: any) => ({
+      nombre: a.auditor_nombre,
+    }));
+
+    this.auditoresAuditoriaTexto = auditores.length
+      ? auditores.map((a: any) => a.auditor_nombre).join(", ")
+      : "Sin auditor(es)";
+  }
+
+  private cargarDatosEnParalelo(): void {
+    const auditoriaId = this.data.auditoria?._id;
+    this.cargando = true;
+
+    const plan$ = auditoriaId
+      ? this.planAuditoriaService
+          .get(
+            `auditoria-auditor?query=auditoria_id:${auditoriaId},activo:true&limit=100`
+          )
+          .pipe(
+            catchError((err) => {
+              console.error("Error al cargar auditores del plan:", err);
+              return of(null);
+            })
+          )
+      : of(null);
+
+    const disponibles$ = this.autenticacionMidService
+      .get("rol/periods")
+      .pipe(
+        catchError((err) => {
+          console.error("Error al cargar auditores disponibles:", err);
+          return of(null);
+        })
+      );
+
+    forkJoin({ plan: plan$, disponibles: disponibles$ }).subscribe({
+      next: ({ plan, disponibles }) => {
+        this.procesarAuditoresDisponibles(disponibles);
+        this.procesarAuditoresPlan(plan);
+        // Filtra disponibles quitando los ya asignados al plan
+        this.auditoresDisponibles = this.auditoresDisponibles.filter(
+          (a) => !this.auditoresPlan.some((ap) => ap.id === a.id)
+        );
+        this.cargando = false;
+      },
+      error: () => {
+        this.cargando = false;
+      },
+    });
+  }
+
+  private procesarAuditoresPlan(res: any): void {
+    const registros: any[] = res?.Data ?? [];
+    this.registrosAuditoresPlan = registros.map((r) => ({
+      registroId: r._id,
+      auditorId: String(r.auditor_id),
+      nombre: r.auditor_nombre ?? `Auditor ${r.auditor_id}`,
+    }));
+    this.auditoresPlan = this.registrosAuditoresPlan.map((r) => ({
+      id: r.auditorId,
+      nombre: r.nombre,
+    }));
+  }
+
+  private procesarAuditoresDisponibles(res: any): void {
+    if (!res?.Data) return;
+
+    const auditorMap = new Map();
+
+    res.Data.filter(
+      (auditor: any) =>
+        auditor.finalizado === false &&
+        ["AUDITOR", "AUDITOR EXPERTO", "AUDITOR ASISTENTE"].includes(
+          auditor.rol_usuario
+        )
+    ).forEach((auditor: any) => {
+      auditorMap.set(auditor.id_tercero, {
+        id: String(auditor.id_tercero),
+        nombre: auditor.nombre,
+      });
+    });
+
+    this.auditoresDisponibles = Array.from(auditorMap.values()) as {
+      id: string;
+      nombre: string;
+    }[];
+  }
+
+  /** Agrega el auditor seleccionado en el dropdown a la lista local */
+  agregarAuditorPlan(): void {
+    if (!this.auditorSeleccionado) return;
+
+    const yaExiste = this.auditoresPlan.some(
+      (a) => a.id === this.auditorSeleccionado!.id
+    );
+    if (yaExiste) {
+      this.alertService.showAlert(
+        "Auditor duplicado",
+        "Este auditor ya fue agregado al plan."
+      );
+      return;
+    }
+
+    this.auditoresPlan = [
+      ...this.auditoresPlan,
+      { ...this.auditorSeleccionado },
+    ];
+    this.auditoresDisponibles = this.auditoresDisponibles.filter(
+      (a) => a.id !== this.auditorSeleccionado!.id
+    );
+    this.auditorSeleccionado = null;
+  }
+
+  /** Elimina un auditor de la lista local y lo marca para eliminar al guardar */
+  eliminarAuditorPlan(index: number): void {
+    const auditor = this.auditoresPlan[index];
+    const registro = this.registrosAuditoresPlan.find(
+      (r) => r.auditorId === auditor.id
+    );
+
+    if (registro) {
+      this.auditoresAEliminar.push(registro.registroId);
+    }
+
+    this.auditoresDisponibles = [...this.auditoresDisponibles, auditor];
+    this.auditoresPlan = this.auditoresPlan.filter((_, i) => i !== index);
+  }
+
+  /** Guarda los cambios: elimina los marcados y crea los nuevos */
+  guardarYCerrar(): void {
+    if (this.auditoresPlan.length === 0) {
+      this.alertService.showAlert(
+        "Sin auditores",
+        "Debe asignar al menos un auditor responsable del plan."
+      );
+      return;
+    }
+
+    this.alertService
+      .showConfirmAlert(
+        "¿Está seguro de guardar los auditores responsables del plan de mejoramiento?"
+      )
+      .then((confirmado) => {
+        if (!confirmado.value) return;
+        this.ejecutarGuardado();
+      });
+  }
+
+  private async ejecutarGuardado(): Promise<void> {
+    this.alertService.showSuccessAlert(
+      "Auditores del plan asignados correctamente.",
+      "Guardado exitoso"
+    );
+    this.dialogRef.close(true);
+  }
+
+  private cambiarEstadoPlanMejoramiento(auditoriaId: string): Promise<any> {
+    return Promise.resolve();
+  }
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.css
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.css
@@ -1,0 +1,121 @@
+.seccion-header {
+  background-color: var(--md-accent-50);
+  color: var(--md-accent-900);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
+.seccion-header b {
+  font-weight: 500;
+}
+
+.hallazgo-vinculado {
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  border-left: 6px solid var(--md-primary-500);
+  font-size: 14px;
+  color: var(--md-accent-900);
+  line-height: 1.5;
+}
+
+.auditor-readonly {
+  padding: 15px;
+  color: var(--md-accent-900);
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  border-left: 6px solid var(--md-primary-500);
+  margin-bottom: 8px;
+  display: flex;
+  align-items: flex-start;
+}
+
+.auditor-readonly .icon-chip {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  font-size: 20px;
+  margin-right: 8px;
+  margin-top: 1px;
+  color: var(--md-primary-500);
+}
+
+.label-lider {
+  display: block;
+  font-size: 11px;
+  color: var(--md-accent-600, #757575);
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+.auditor-tag {
+  border: 1px solid var(--md-accent-600);
+  padding: 5px;
+  padding-right: 10px;
+  border-radius: 10px;
+  font-size: 12px;
+  margin-left: 8px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.auditor-tag mat-icon {
+  width: 15px;
+  height: 15px;
+  font-size: 15px;
+  margin-right: 3px;
+  margin-bottom: -4px;
+  color: var(--md-accent-600);
+}
+
+.info-guardar {
+  padding: 15px;
+  color: var(--md-accent-900);
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  border-left: 6px solid var(--md-primary-500);
+}
+
+.info-guardar mat-icon {
+  width: 15px;
+  height: 15px;
+  font-size: 15px;
+  margin-right: 8px;
+  color: var(--md-primary-500);
+}
+
+.info-guardar p {
+  font-size: 13px;
+  color: var(--md-accent-900);
+  margin: 0;
+}
+
+.btn-cerrar {
+  border: 1px solid var(--md-primary-500) !important;
+}
+
+.btn-agregar {
+  white-space: nowrap;
+  height: 40px;
+}
+
+.tip-suffix {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  cursor: help;
+  opacity: 0.55;
+  transition: opacity 0.15s ease;
+  align-self: flex-start;
+  margin-top: 2px;
+}
+
+.tip-suffix:hover {
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .auditor-tag {
+    font-size: 9.5px;
+  }
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.html
@@ -1,0 +1,193 @@
+<plantilla-modal
+  [icono]="'edit'"
+  [titulo]="modoEdicion ? 'Editar Acción' : 'Registrar Acción'"
+  [descripcion]="'Hallazgo ' + data.hallazgo.indice + ' ' + data.hallazgo.descripcion"
+  [contenido]="contenidoDeModal"
+  [footer]="footerDeModal"
+></plantilla-modal>
+
+<ng-template #contenidoDeModal>
+  <form [formGroup]="form" class="row mt-3">
+
+    <div class="col-12 mb-3">
+      <div class="seccion-header text-center mb-2">
+        <b>Hallazgo Vinculado</b>
+      </div>
+      <div class="hallazgo-vinculado p-3">
+        <p class="mb-0">{{ data.hallazgo.descripcion }}</p>
+      </div>
+    </div>
+
+    <div class="col-12 mb-3">
+      <div class="seccion-header text-center mb-2">
+        <b>Causa del Hallazgo <span class="text-danger">*</span></b>
+      </div>
+      <mat-form-field appearance="outline" class="col-12">
+        <mat-label>Causa del Hallazgo</mat-label>
+        <textarea matInput formControlName="causa"
+          rows="3" placeholder="Descripción de la causa del hallazgo"></textarea>
+        <mat-icon matSuffix color="primary" class="tip-suffix"
+          [matTooltip]="tooltips.causa"
+          matTooltipPosition="right"
+          matTooltipClass="tooltip-multilinea">help_outline</mat-icon>
+        <mat-error *ngIf="form.get('causa')?.hasError('required')">Campo requerido</mat-error>
+      </mat-form-field>
+    </div>
+
+    <div class="col-12 mb-3">
+      <div class="seccion-header text-center mb-2">
+        <b>Descripción de la Acción</b>
+      </div>
+
+      <div class="row mb-3 mt-2">
+        <div class="col-md-3 col-12">
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>No. Acción</mat-label>
+            <input matInput [value]="data.accion?.numero || 'Autogenerado'" readonly />
+          </mat-form-field>
+        </div>
+        <div class="col-md-9 col-12">
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>Tipo de Acción <span class="text-danger">*</span></mat-label>
+            <mat-select formControlName="tipoAccion">
+              <mat-option *ngFor="let tipo of tiposAccion" [value]="tipo.id">
+                {{ tipo.nombre }}
+              </mat-option>
+            </mat-select>
+            <mat-icon matSuffix color="primary" class="tip-suffix"
+              [matTooltip]="form.get('tipoAccion')?.value === 1 ? tooltips.accionPreventiva : tooltips.accionCorrectiva"
+              matTooltipPosition="right"
+              matTooltipClass="tooltip-multilinea">help_outline</mat-icon>
+            <mat-error *ngIf="form.get('tipoAccion')?.hasError('required')">Campo requerido</mat-error>
+          </mat-form-field>
+        </div>
+      </div>
+
+      <mat-form-field appearance="outline" class="col-12 mb-3">
+        <mat-label>Acción Planteada <span class="text-danger">*</span></mat-label>
+        <textarea matInput formControlName="accionPlanteada"
+          rows="3" placeholder="Descripción de la acción planteada"></textarea>
+        <mat-icon matSuffix color="primary" class="tip-suffix"
+          [matTooltip]="tooltips.accionPlanteada"
+          matTooltipPosition="right"
+          matTooltipClass="tooltip-multilinea">help_outline</mat-icon>
+        <mat-error *ngIf="form.get('accionPlanteada')?.hasError('required')">Campo requerido</mat-error>
+      </mat-form-field>
+
+      <!-- Indicadores: Nombre | Fórmula | Meta -->
+      <div class="row">
+        <div class="col-md-4 col-12">
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>Nombre Indicador</mat-label>
+            <mat-icon matPrefix color="primary">show_chart</mat-icon>
+            <input matInput formControlName="nombreIndicador" />
+            <mat-icon matSuffix color="primary" class="tip-suffix"
+              [matTooltip]="tooltips.nombreIndicador"
+              matTooltipPosition="above"
+              matTooltipClass="tooltip-multilinea">help_outline</mat-icon>
+          </mat-form-field>
+        </div>
+        <div class="col-md-4 col-12">
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>Fórmula Indicador</mat-label>
+            <mat-icon matPrefix color="primary">functions</mat-icon>
+            <input matInput formControlName="formulaIndicador" />
+            <mat-icon matSuffix color="primary" class="tip-suffix"
+              [matTooltip]="tooltips.formulaIndicador"
+              matTooltipPosition="above"
+              matTooltipClass="tooltip-multilinea">help_outline</mat-icon>
+          </mat-form-field>
+        </div>
+        <div class="col-md-4 col-12">
+          <mat-form-field appearance="outline" class="col-12">
+            <mat-label>Meta</mat-label>
+            <mat-icon matPrefix color="primary">flag</mat-icon>
+            <input matInput formControlName="meta" />
+            <mat-icon matSuffix color="primary" class="tip-suffix"
+              [matTooltip]="tooltips.meta"
+              matTooltipPosition="above"
+              matTooltipClass="tooltip-multilinea">help_outline</mat-icon>
+          </mat-form-field>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Responsables ───────────────────────────────────────────────── -->
+    <div class="col-12 mb-2">
+      <p class="mb-2">
+        <b>Responsables <span class="text-danger">*</span></b>
+      </p>
+
+      <!-- Dependencia Líder (read-only) -->
+      <div class="auditor-readonly mb-2">
+        <mat-icon class="icon-chip">business</mat-icon>
+        <div>
+          <span class="label-lider">Dependencia Líder Acciones</span>
+          <p class="mb-0">{{ dependenciaLider || 'Sin dependencia líder' }}</p>
+        </div>
+        <span class="auditor-tag ms-auto">
+          <mat-icon>star</mat-icon> Líder
+        </span>
+      </div>
+
+      <!-- Lista de responsables ya agregados -->
+      <div
+        *ngFor="let resp of responsablesAgregados; let i = index"
+        class="auditor-readonly d-flex align-items-center justify-content-between mb-2"
+      >
+        <div class="d-flex align-items-center">
+          <mat-icon class="icon-chip">person</mat-icon>
+          <span>{{ resp.nombre }}</span>
+          <span class="auditor-tag">
+            <mat-icon>badge</mat-icon>
+            Responsable {{ i + 1 }}
+          </span>
+        </div>
+        <button mat-icon-button color="warn"
+          (click)="eliminarResponsable(i)"
+          matTooltip="Eliminar responsable"
+          type="button">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+
+      <!-- Selector + botón Agregar -->
+      <div class="d-flex align-items-center mt-2 gap-2">
+        <mat-form-field appearance="outline" class="flex-grow-1">
+          <mat-label>Dependencia Responsable de Acción</mat-label>
+          <mat-icon color="primary" matPrefix>person_search</mat-icon>
+          <mat-select [(ngModel)]="responsableSeleccionado" [ngModelOptions]="{standalone: true}">
+            <mat-option *ngFor="let dep of dependenciasDisponibles" [value]="dep">
+              {{ dep.nombre }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button mat-raised-button color="primary"
+          class="btn-agregar mb-4"
+          type="button"
+          [disabled]="!responsableSeleccionado"
+          (click)="agregarResponsable()">
+          <mat-icon>add</mat-icon> Agregar Responsable
+        </button>
+      </div>
+
+      <!-- Info guardar -->
+      <div class="info-guardar d-flex align-items-center my-2">
+        <mat-icon>info</mat-icon>
+        <p class="mb-0 ms-2">¿Guardar cambios?</p>
+      </div>
+    </div>
+
+  </form>
+</ng-template>
+
+<ng-template #footerDeModal>
+  <div class="d-flex justify-content-end gap-2 mb-3">
+    <button mat-stroked-button color="warn" class="btn-cerrar" [mat-dialog-close]>
+      <mat-icon>close</mat-icon> No, cerrar
+    </button>
+    <button mat-raised-button color="primary" (click)="guardarYCerrar()">
+      <mat-icon>save</mat-icon> Sí, guardar y cerrar
+    </button>
+  </div>
+</ng-template>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.ts
@@ -1,0 +1,182 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { AlertService } from 'src/app/shared/services/alert.service';
+import { AccionPlan } from '../tabla-hallazgos/tabla-hallazgos.component';
+
+export interface DatosModalAccion {
+  hallazgo: any;
+  accion: AccionPlan | null;
+  auditoria: any;
+}
+
+export interface Dependencia {
+  id: string;
+  nombre: string;
+}
+
+@Component({
+  selector: 'app-modal-registrar-accion',
+  templateUrl: './modal-registrar-accion.component.html',
+  styleUrls: ['./modal-registrar-accion.component.css'],
+})
+export class ModalRegistrarAccionComponent implements OnInit {
+  form!: FormGroup;
+  modoEdicion = false;
+  /** Nombre de la dependencia líder (read-only, viene de la auditoría) */
+  dependenciaLider = '';
+
+  /** Lista de dependencias disponibles para seleccionar (mock para pruebas) */
+  dependenciasDisponibles: Dependencia[] = [
+    { id: '1', nombre: 'Oficina de Control Interno' },
+    { id: '2', nombre: 'Gestión de Docencia' },
+    { id: '3', nombre: 'Gestión de Bienestar' },
+    { id: '4', nombre: 'Gestión Financiera' },
+    { id: '5', nombre: 'Gestión de TI' },
+  ];
+
+  /** Dependencia actualmente seleccionada en el dropdown */
+  responsableSeleccionado: Dependencia | null = null;
+
+  /** Responsables ya agregados (se muestran como chips) */
+  responsablesAgregados: Dependencia[] = [];
+  tiposAccion = [
+    { id: 1, nombre: 'Preventiva' },
+    { id: 2, nombre: 'Correctiva' },
+  ];
+
+  readonly tooltips = {
+    causa:
+      'Motivo por el cual se presentó el hallazgo determinado en el ejercicio de Auditoría. Se debe realizar una descripción precisa intentando transcribir el enunciado del hallazgo. Se sugiere el uso de herramientas que permitan realizar un análisis de causa raíz.',
+    accionPreventiva:
+      'Mecanismo utilizado por las entidades para evitar las causas de una situación no deseable que puede llegar a afectar el normal cumplimiento del quehacer institucional (Fuente: Función Pública).',
+    accionCorrectiva:
+      'Mecanismo utilizado por las entidades para eliminar las causas de una situación no deseable que afectó el normal cumplimiento del quehacer institucional. Acción usada como respuesta a un ejercicio de Auditoría (Fuente: Función Pública).',
+    accionPlanteada:
+      'Actividad que realizará la(s) dependencia(s) responsable(s), con el objetivo de subsanar la causa raíz de la situación descrita en el informe final de Auditoría o documento equivalente. Debe iniciar con un verbo en infinitivo.',
+    formulaIndicador:
+      'Representación cuantitativa que debe ser expresada en variable o relación entre variables, que permitan medir el cumplimiento de la acción determinada y así realizar una evaluación objetiva.',
+    nombreIndicador:
+      'Instrumento de medida que permite analizar la relación entre dos o más variables con el fin de determinar el avance o retroceso en el logro de un objetivo en un período determinado (Fuente: Función Pública).',
+    meta:
+      'Representa el porcentaje de cumplimiento determinado para la actividad. Debe expresarse de forma cuantificable y que esté directamente relacionada con la acción planteada.',
+  };
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: DatosModalAccion,
+    private readonly dialogRef: MatDialogRef<ModalRegistrarAccionComponent>,
+    private readonly fb: FormBuilder,
+    private readonly alertService: AlertService,
+  ) {}
+
+  ngOnInit(): void {
+    this.modoEdicion = !!this.data.accion;
+    this.iniciarForm();
+    this.iniciarResponsables();
+    if (this.modoEdicion) this.poblarForm();
+  }
+
+  private iniciarForm(): void {
+    this.form = this.fb.group({
+      causa:            ['', Validators.required],
+      tipoAccion:       ['', Validators.required],
+      accionPlanteada:  ['', Validators.required],
+      nombreIndicador:  [''],
+      formulaIndicador: [''],
+      meta:             [''],
+    });
+  }
+
+  private iniciarResponsables(): void {
+    // Dependencia líder viene de la auditoría (read-only)
+    this.dependenciaLider =
+      this.data.auditoria?.jefe_nombre ??
+      this.data.auditoria?.dependencia_nombre ??
+      '';
+  }
+
+  private poblarForm(): void {
+    const a = this.data.accion!;
+    this.form.patchValue({
+      causa:            a.tipoAccion,
+      tipoAccion:       a.tipoAccion,
+      accionPlanteada:  a.accionPlanteada,
+      nombreIndicador:  a.nombreIndicador,
+      formulaIndicador: a.formulaIndicador,
+      meta:             a.meta,
+    });
+
+    // Restaurar responsables guardados en la acción
+    if (a.responsable) {
+      this.responsablesAgregados = [{ id: '0', nombre: a.responsable }];
+    }
+  }
+
+  agregarResponsable(): void {
+    if (!this.responsableSeleccionado) return;
+
+    const yaExiste = this.responsablesAgregados.some(
+      r => r.id === this.responsableSeleccionado!.id
+    );
+    if (yaExiste) {
+      this.alertService.showAlert(
+        'Responsable duplicado',
+        'Esta dependencia ya fue agregada como responsable.'
+      );
+      return;
+    }
+
+    this.responsablesAgregados = [...this.responsablesAgregados, { ...this.responsableSeleccionado }];
+    this.dependenciasDisponibles = this.dependenciasDisponibles.filter(
+      d => d.id !== this.responsableSeleccionado!.id
+    );
+    this.responsableSeleccionado = null;
+  }
+
+  eliminarResponsable(index: number): void {
+    const eliminado = this.responsablesAgregados[index];
+    // Devolver al dropdown
+    this.dependenciasDisponibles = [...this.dependenciasDisponibles, eliminado];
+    this.responsablesAgregados = this.responsablesAgregados.filter((_, i) => i !== index);
+  }
+
+  guardarYCerrar(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this.alertService.showErrorAlert('Complete todos los campos obligatorios.');
+      return;
+    }
+
+    if (this.responsablesAgregados.length === 0) {
+      this.alertService.showAlert(
+        'Sin responsables',
+        'Debe agregar al menos un responsable de la acción.'
+      );
+      return;
+    }
+
+    this.alertService
+      .showConfirmAlert('¿Guardar cambios?')
+      .then((confirmado) => {
+        if (!confirmado.value) return;
+
+        const v = this.form.value;
+
+        const accionGuardada: AccionPlan = {
+          numero:           this.data.accion?.numero ?? '',
+          tipoAccion:       this.tiposAccion.find(t => t.id === v.tipoAccion)?.nombre ?? v.tipoAccion,
+          accionPlanteada:  v.accionPlanteada,
+          nombreIndicador:  v.nombreIndicador,
+          formulaIndicador: v.formulaIndicador,
+          meta:             v.meta,
+          // Concatenar nombres de responsables si hay varios
+          responsable:      this.responsablesAgregados.map(r => r.nombre).join(', '),
+          fechaInicio:      '',
+          fechaFin:         '',
+        };
+
+        this.alertService.showSuccessAlert('Acción guardada correctamente.', 'Guardado');
+        this.dialogRef.close(accionGuardada);
+      });
+  }
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.css
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.css
@@ -1,0 +1,12 @@
+.seccion-titulo {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.separador {
+  border: 0;
+  height: 2px;
+  background: var(--primary);
+  opacity: 0.2;
+  margin: 0.5rem 0 1rem;
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.html
@@ -1,0 +1,79 @@
+<plantilla-tarjeta-contenedora
+  [title]="'Editar Plan de Mejoramiento'"
+  [breadcrumb]="'<p>Planes de Mejoramiento / Registrar Plan / <b>Editar Plan de Mejoramiento</b></p>'"
+  [contenido]="contenidoDePlantilla"
+  [mostrarBotonRegresar]="true"
+  (regresar)="regresar()"
+>
+</plantilla-tarjeta-contenedora>
+
+<ng-template #contenidoDePlantilla>
+
+  <!-- Información Plan de Mejoramiento (read-only) -->
+  <div class="row mt-3">
+    <div class="col-12 mb-3">
+      <h5 class="seccion-titulo">Información Plan de Mejoramiento</h5>
+    </div>
+    <mat-form-field appearance="outline" class="col-md-3 col-12">
+      <mat-label>No. Auditoría</mat-label>
+      <input matInput [value]="auditoria?.consecutivo_no_auditoria || ''" readonly />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="col-md-5 col-12">
+      <mat-label>Nombre de auditoría</mat-label>
+      <input matInput [value]="auditoria?.titulo || ''" readonly />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="col-md-4 col-12">
+      <mat-label>Proceso Responsable</mat-label>
+      <input matInput [value]="auditoria?.proceso_nombre || ''" readonly />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="col-md-4 col-12">
+      <mat-label>Líder del Proceso</mat-label>
+      <input matInput [value]="auditoria?.jefe_nombre || ''" readonly />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="col-md-4 col-12">
+      <mat-label>Gestores del Proceso</mat-label>
+      <input matInput [value]="auditoria?.dependencia_nombre || ''" readonly />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="col-md-2 col-12">
+      <mat-label>Fecha (DD/MM/AA)</mat-label>
+      <input matInput [value]="auditoria?.fecha_inicio | date:'dd/MM/yy'" readonly />
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="col-md-2 col-12">
+      <mat-label>Seleccione una opción</mat-label>
+      <mat-select>
+        <!-- opciones dinámicas si aplica -->
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <hr class="separador" />
+
+  <!-- Tabla de hallazgos -->
+  <div class="row mt-3">
+    <div class="col-12 mb-2">
+      <h5 class="seccion-titulo mb-1">Formulación Plan de Trabajo</h5>
+      <p class="text-muted small mb-0">Seleccione el hallazgo para agregar y/o editar plan de acción</p>
+    </div>
+    <div class="col-12">
+      <app-tabla-hallazgos
+        *ngIf="auditoria"
+        [auditoriaId]="auditoriaId"
+        [auditoria]="auditoria"
+      ></app-tabla-hallazgos>
+    </div>
+  </div>
+
+<!-- Footer -->
+    <div class="d-flex justify-content-end mt-4" style="gap: 16px;">
+    <button mat-raised-button color="primary">
+        <mat-icon>visibility</mat-icon>
+        Vista Previa
+    </button>
+    <button mat-raised-button color="primary">Guardar</button>
+    <button mat-stroked-button color="primary">
+        <mat-icon>send</mat-icon>
+        Enviar a Auditor
+    </button>
+    </div>
+
+</ng-template>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { PlanAnualAuditoriaMid } from 'src/app/core/services/plan-anual-auditoria-mid.service';
+
+@Component({
+  selector: 'app-registrar-plan',
+  templateUrl: './registrar-plan.component.html',
+  styleUrls: ['./registrar-plan.component.css'],
+})
+export class RegistrarPlanComponent implements OnInit {
+  auditoriaId!: string;
+  auditoria: any = null;
+  cargando = true;
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly planAuditoriaMid: PlanAnualAuditoriaMid,
+  ) {}
+
+  ngOnInit(): void {
+    this.auditoriaId = this.route.snapshot.paramMap.get('id')!;
+    this.cargarAuditoria();
+  }
+
+  cargarAuditoria(): void {
+    this.planAuditoriaMid.get(`auditoria/${this.auditoriaId}`).subscribe({
+      next: (res) => {
+        this.auditoria = res.Data;
+        this.cargando = false;
+      },
+      error: () => { this.cargando = false; }
+    });
+  }
+
+  regresar(): void {
+    this.router.navigate(['/planes/plan-mejoramiento']);
+  }
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.css
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.css
@@ -1,0 +1,32 @@
+/* Fila de cabecera de hallazgo */
+.fila-grupo-row td {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #e0e0e0;
+  padding: 4px 8px !important;
+}
+
+.fila-grupo-row:hover td {
+  background-color: #eeeeee;
+}
+
+/* Ícono +/- de expansión */
+.icono-grupo {
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+  vertical-align: middle;
+  color: var(--primary, #3f51b5);
+}
+
+/* Filas de acción */
+.fila-accion-row td {
+  padding-top: 6px !important;
+  padding-bottom: 6px !important;
+}
+
+/* Botón agregar acción compacto */
+.fila-grupo-row button {
+  height: 30px;
+  line-height: 30px;
+  font-size: 13px;
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.html
@@ -1,0 +1,144 @@
+<div *ngIf="cargando" class="text-center py-4">
+  <mat-spinner diameter="40" class="mx-auto"></mat-spinner>
+</div>
+
+<div *ngIf="!cargando">
+
+  <!-- Cabecera exportar -->
+  <div class="d-flex justify-content-end mb-2">
+    <button mat-stroked-button color="primary">
+      <mat-icon>upload</mat-icon> Exportar tabla
+    </button>
+  </div>
+
+  <div class="table-container rounded-table table-scroll">
+    <table mat-table [dataSource]="filas" class="w-100">
+
+      <!-- No Hallazgo -->
+      <ng-container matColumnDef="noHallazgo">
+        <th mat-header-cell *matHeaderCellDef><b>No Hallazgo</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.hallazgoIndice }}</td>
+      </ng-container>
+
+      <!-- Descripción del Hallazgo -->
+      <ng-container matColumnDef="descripcion">
+        <th mat-header-cell *matHeaderCellDef><b>Descripción del Hallazgo</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.hallazgoDescripcion }}</td>
+      </ng-container>
+
+      <!-- Causa del Hallazgo -->
+      <ng-container matColumnDef="causa">
+        <th mat-header-cell *matHeaderCellDef><b>Causa del Hallazgo</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.hallazgoCausa || 'Sin causa registrada' }}</td>
+      </ng-container>
+
+      <!-- No. Acción -->
+      <ng-container matColumnDef="numero">
+        <th mat-header-cell *matHeaderCellDef><b>No. Acción</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.numero }}</td>
+      </ng-container>
+
+      <!-- Tipo de Acción -->
+      <ng-container matColumnDef="tipoAccion">
+        <th mat-header-cell *matHeaderCellDef><b>Tipo de Acción</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.tipoAccion ?? 'Sin Tipo' }}</td>
+      </ng-container>
+
+      <!-- Acción Planteada -->
+      <ng-container matColumnDef="accionPlanteada">
+        <th mat-header-cell *matHeaderCellDef><b>Acción Planteada</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.accionPlanteada ?? 'Sin Acción' }}</td>
+      </ng-container>
+
+      <!-- Nombre Indicador -->
+      <ng-container matColumnDef="nombreIndicador">
+        <th mat-header-cell *matHeaderCellDef><b>Nombre de Indicador</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.nombreIndicador }}</td>
+      </ng-container>
+
+      <!-- Fórmula Indicador -->
+      <ng-container matColumnDef="formulaIndicador">
+        <th mat-header-cell *matHeaderCellDef><b>Formula de Indicador</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.formulaIndicador }}</td>
+      </ng-container>
+
+      <!-- Meta -->
+      <ng-container matColumnDef="meta">
+        <th mat-header-cell *matHeaderCellDef><b>Meta</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.meta }}</td>
+      </ng-container>
+
+      <!-- Responsable -->
+      <ng-container matColumnDef="responsable">
+        <th mat-header-cell *matHeaderCellDef><b>Responsable de la Acción</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.responsable }}</td>
+      </ng-container>
+
+      <!-- Fecha Inicio -->
+      <ng-container matColumnDef="fechaInicio">
+        <th mat-header-cell *matHeaderCellDef><b>Fecha Inicio</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.fechaInicio }}</td>
+      </ng-container>
+
+      <!-- Fecha Fin -->
+      <ng-container matColumnDef="fechaFin">
+        <th mat-header-cell *matHeaderCellDef><b>Fecha Fin</b></th>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.fechaFin }}</td>
+      </ng-container>
+
+      <!-- Acciones (menú) -->
+      <ng-container matColumnDef="acciones">
+        <th mat-header-cell *matHeaderCellDef><b>Acciones</b></th>
+        <td mat-cell *matCellDef="let fila">
+          <button mat-icon-button color="primary" [matMenuTriggerFor]="menuAccion">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #menuAccion="matMenu">
+            <button mat-menu-item
+              (click)="abrirModalRegistrarAccion(getHallazgo(fila.hallazgoId), fila.accion)">
+              <mat-icon color="primary">edit</mat-icon> Editar Acción
+            </button>
+            <button mat-menu-item
+              (click)="eliminarAccion(getHallazgo(fila.hallazgoId), fila.accion)">
+              <mat-icon color="warn">delete</mat-icon> Eliminar Acción
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+
+      <!-- ── Columna de GRUPO (ocupa todo el ancho) ── -->
+      <ng-container matColumnDef="grupo">
+        <td mat-cell *matCellDef="let fila" [attr.colspan]="columnas.length + 1">
+          <div class="d-flex align-items-center justify-content-between px-1 py-1">
+            <span class="d-flex align-items-center gap-1" style="cursor:pointer"
+                  (click)="toggleHallazgo(fila.hallazgoId)">
+              <mat-icon class="icono-grupo">
+                {{ getHallazgo(fila.hallazgoId)?.expandido ? 'remove' : 'add' }}
+              </mat-icon>
+              <b>{{ fila.hallazgoIndice }}</b>&nbsp;&nbsp;{{ fila.hallazgoDescripcion }}
+            </span>
+            <button mat-stroked-button color="primary"
+              (click)="abrirModalRegistrarAccion(getHallazgo(fila.hallazgoId))">
+              <mat-icon>add</mat-icon> Agregar Acción
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnas; sticky: true"></tr>
+
+      <!-- Fila de grupo -->
+      <tr mat-row
+          *matRowDef="let fila; columns: ['grupo']; when: esFilaGrupo"
+          class="fila-grupo-row">
+      </tr>
+
+      <!-- Fila de acción (solo visible si el hallazgo está expandido) -->
+      <tr mat-row
+          *matRowDef="let fila; columns: columnas; when: esFilaAccion"
+          class="fila-accion-row">
+      </tr>
+
+    </table>
+  </div>
+</div>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.ts
@@ -1,0 +1,239 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { PlanAnualAuditoriaService } from 'src/app/core/services/plan-anual-auditoria.service';
+import { ModalRegistrarAccionComponent } from '../modal-registrar-accion/modal-registrar-accion.component';
+
+export interface HallazgoTabla {
+  hallazgoId: string;
+  indice: string;
+  descripcion: string;
+  causa: string;
+  acciones: AccionPlan[];
+  expandido: boolean;
+}
+
+export interface AccionPlan {
+  accionId?: string;
+  numero: string;
+  tipoAccion: string;
+  accionPlanteada: string;
+  nombreIndicador: string;
+  formulaIndicador: string;
+  meta: string;
+  responsable: string;
+  fechaInicio: string;
+  fechaFin: string;
+}
+
+/**
+ * Fila del datasource plano.
+ * - esGrupo = true  → fila de cabecera del hallazgo (usa columna 'grupo')
+ * - esGrupo = false → fila de una acción concreta (usa columnas normales)
+ */
+export interface FilaTabla {
+  esGrupo: boolean;
+  hallazgoId: string;
+  hallazgoIndice: string;
+  hallazgoDescripcion: string;
+  hallazgoCausa: string;        // ← criterio del hallazgo (campo 'criterio' del backend)
+  accion?: AccionPlan;
+}
+
+@Component({
+  selector: 'app-tabla-hallazgos',
+  templateUrl: './tabla-hallazgos.component.html',
+  styleUrls: ['./tabla-hallazgos.component.css'],
+})
+export class TablaHallazgosComponent implements OnInit {
+  @Input() auditoriaId!: string;
+  @Input() auditoria: any;
+
+  hallazgos: HallazgoTabla[] = [];
+  filas: FilaTabla[] = [];
+  cargando = true;
+  informeId!: string;
+
+  columnas = [
+    'noHallazgo', 'descripcion', 'causa', 'numero', 'tipoAccion',
+    'accionPlanteada', 'nombreIndicador', 'formulaIndicador',
+    'meta', 'responsable', 'fechaInicio', 'fechaFin', 'acciones',
+  ];
+
+  esFilaGrupo  = (_i: number, fila: FilaTabla) =>  fila.esGrupo;
+  esFilaAccion = (_i: number, fila: FilaTabla) => !fila.esGrupo;
+
+  constructor(
+    private readonly planAuditoriaService: PlanAnualAuditoriaService,
+    private readonly dialog: MatDialog,
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarHallazgos();
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+  getHallazgo(hallazgoId: string): HallazgoTabla | undefined {
+    return this.hallazgos.find(h => h.hallazgoId === hallazgoId);
+  }
+
+  private reconstruirFilas(): void {
+    const filas: FilaTabla[] = [];
+
+    this.hallazgos.forEach(h => {
+      // Fila de cabecera del hallazgo (siempre visible)
+      filas.push({
+        esGrupo:             true,
+        hallazgoId:          h.hallazgoId,
+        hallazgoIndice:      h.indice,
+        hallazgoDescripcion: h.descripcion,
+        hallazgoCausa:       h.causa,
+      });
+
+      if (h.expandido) {
+        if (h.acciones.length > 0) {
+          h.acciones.forEach(accion => {
+            filas.push({
+              esGrupo:             false,
+              hallazgoId:          h.hallazgoId,
+              hallazgoIndice:      h.indice,
+              hallazgoDescripcion: h.descripcion,
+              hallazgoCausa:       h.causa,
+              accion,
+            });
+          });
+        } else {
+          // Fila placeholder cuando no hay acciones
+          filas.push({
+            esGrupo:             false,
+            hallazgoId:          h.hallazgoId,
+            hallazgoIndice:      h.indice,
+            hallazgoDescripcion: h.descripcion,
+            hallazgoCausa:       h.causa,
+            accion:              undefined,
+          });
+        }
+      }
+    });
+
+    this.filas = filas;
+  }
+
+  // ─── Carga de datos ──────────────────────────────────────────────────────────
+
+  cargarHallazgos(): void {
+    const estadoPrevio = new Map<string, { expandido: boolean; acciones: AccionPlan[] }>();
+    this.hallazgos.forEach(h => estadoPrevio.set(h.hallazgoId, {
+      expandido: h.expandido,
+      acciones:  h.acciones,
+    }));
+
+    this.planAuditoriaService
+      .get(`informe?query=auditoria_id:${this.auditoriaId},activo:true`)
+      .subscribe({
+        next: (res) => {
+          if (!res.Data?.length) { this.cargando = false; return; }
+          this.informeId = res.Data[0]._id;
+          this.cargarHallazgosDeInforme(estadoPrevio);
+        },
+        error: () => { this.cargando = false; }
+      });
+  }
+
+  private cargarHallazgosDeInforme(
+    estadoPrevio: Map<string, { expandido: boolean; acciones: AccionPlan[] }>
+  ): void {
+    this.planAuditoriaService
+      .get(`tema?query=informe_id:${this.informeId}`)
+      .subscribe({
+        next: (res) => {
+          const temas: any[] = res.Data ?? [];
+          const hallazgosList: HallazgoTabla[] = [];
+          let temaCount = 0;
+
+          temas.forEach((tema: any) => {
+            if (!tema.activo) return;
+            temaCount++;
+            let subtemaCount = 0;
+
+            (tema.subtema ?? []).forEach((subtema: any) => {
+              if (!subtema.activo) return;
+              subtemaCount++;
+              let hallazgoCount = 0;
+
+              (subtema.hallazgo ?? []).forEach((hallazgo: any) => {
+                if (!hallazgo.activo) return;
+                hallazgoCount++;
+
+                const previo = estadoPrevio.get(hallazgo._id);
+                hallazgosList.push({
+                  hallazgoId:  hallazgo._id,
+                  indice:      `${temaCount}.${subtemaCount}.${hallazgoCount}`,
+                  descripcion: hallazgo.descripcion ?? hallazgo.titulo ?? '',
+                  causa:       hallazgo.criterio   ?? '',   // ← campo correcto del backend
+                  acciones:    previo?.acciones  ?? [],
+                  expandido:   previo?.expandido ?? false,
+                });
+              });
+            });
+          });
+
+          this.hallazgos = hallazgosList;
+          this.reconstruirFilas();
+          this.cargando = false;
+        },
+        error: () => { this.cargando = false; }
+      });
+  }
+
+  // ─── Expansión ───────────────────────────────────────────────────────────────
+
+  toggleHallazgo(hallazgoId: string): void {
+    const h = this.getHallazgo(hallazgoId);
+    if (!h) return;
+    h.expandido = !h.expandido;
+    this.reconstruirFilas();
+  }
+
+  // ─── Modal ───────────────────────────────────────────────────────────────────
+
+  abrirModalRegistrarAccion(hallazgo: HallazgoTabla | undefined, accion?: AccionPlan): void {
+    if (!hallazgo) return;
+
+    const dialogRef = this.dialog.open(ModalRegistrarAccionComponent, {
+      width: '900px',
+      data: {
+        hallazgo,
+        accion: accion ?? null,
+        auditoria: this.auditoria,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe((resultado: AccionPlan | null) => {
+      if (!resultado) return;
+
+      if (accion) {
+        const idx = hallazgo.acciones.indexOf(accion);
+        if (idx !== -1) hallazgo.acciones[idx] = resultado;
+      } else {
+        hallazgo.acciones.push({
+          ...resultado,
+          numero: String(hallazgo.acciones.length + 1),
+        });
+      }
+
+      hallazgo.expandido = true;
+      this.reconstruirFilas();
+    });
+  }
+
+  // ─── Eliminar (mock local) ───────────────────────────────────────────────────
+
+  eliminarAccion(hallazgo: HallazgoTabla | undefined, accion: AccionPlan | undefined): void {
+    if (!hallazgo || !accion) return;
+    hallazgo.acciones = hallazgo.acciones
+      .filter(a => a !== accion)
+      .map((a, i) => ({ ...a, numero: String(i + 1) }));
+    this.reconstruirFilas();
+  }
+}

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.html
@@ -3,47 +3,71 @@
     <div class="col-12">
       <h3 class="my-3">Lista de planes de mejoramiento</h3>
       <p class="mb-2 mx-2">
-        Seleccione la auditoría interna a realizar plan de mejoramiento.
+        Seleccione la auditoría interna para realizar el plan de mejoramiento.
       </p>
     </div>
     <div class="col-12">
       <div class="table-container rounded-table table-scroll">
         <table mat-table [dataSource]="planesDataSource" matSort>
-          <ng-container *ngFor="let columna of planesConstructorTabla" [matColumnDef]="columna.columnDef">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header [disabled]="!columna.sortable">
+          <ng-container
+            *ngFor="let columna of planesConstructorTabla"
+            [matColumnDef]="columna.columnDef"
+          >
+            <th
+              mat-header-cell
+              *matHeaderCellDef
+              mat-sort-header
+              [disabled]="!columna.sortable"
+            >
               <b>{{ columna.header }}</b>
             </th>
-            <td mat-cell *matCellDef="let row; let i = index" [ngClass]="{ 'even-row': i % 2 === 0 }">
+            <td
+              mat-cell
+              *matCellDef="let row; let i = index"
+              [ngClass]="{ 'even-row': i % 2 === 0 }"
+            >
               <ng-container *ngIf="columna.columnDef as colDef" [ngSwitch]="colDef">
+
                 <div *ngSwitchCase="'numero'">
                   <span>{{ pageIndex * pageSize + i + 1 }}</span>
                 </div>
+
                 <div *ngSwitchCase="'acciones'">
-                  <button mat-icon-button [matMenuTriggerFor]="menu" color="primary">
-                    <mat-icon>more_vert</mat-icon>
-                  </button>
-                  <mat-menu #menu="matMenu">
-                    <button mat-menu-item (click)="registrarPlan(row)">
-                      <mat-icon color="primary">edit</mat-icon> Registrar Plan
+                  <ng-container *ngIf="row.acciones?.length > 0">
+                    <button mat-icon-button color="primary" [matMenuTriggerFor]="menu">
+                      <mat-icon>more_vert</mat-icon>
                     </button>
-                    <button mat-menu-item (click)="enviarAprobacion(row)">
-                      <mat-icon color="primary">send</mat-icon> Enviar Aprobación
-                    </button>
-                    <button mat-menu-item (click)="verDocumentosAuditoria(row)">
-                      <mat-icon color="primary">description</mat-icon> Documentos Auditoría
-                    </button>
-                  </mat-menu>
+                    <mat-menu #menu="matMenu">
+                      <button
+                        mat-menu-item
+                        *ngFor="let accion of row.acciones"
+                        (click)="realizarAccion(row, accion)"
+                      >
+                        <mat-icon color="primary">{{ getIconoAccion(accion) }}</mat-icon>
+                        <span>{{ accion }}</span>
+                      </button>
+                    </mat-menu>
+                  </ng-container>
                 </div>
+
                 <span *ngSwitchDefault>{{ columna.cell(row) }}</span>
               </ng-container>
             </td>
           </ng-container>
+
           <tr mat-header-row *matHeaderRowDef="tablaColumnas"></tr>
           <tr mat-row *matRowDef="let row; columns: tablaColumnas"></tr>
         </table>
       </div>
-      <mat-paginator #paginator class="mt-3" [length]="totalRegistros" [pageSize]="pageSize"
-        (page)="manejarCambioPaginado($event)" [pageSizeOptions]="itemsPerPage" showFirstLastButtons></mat-paginator>
+      <mat-paginator
+        #paginator
+        class="mt-3"
+        [length]="totalRegistros"
+        [pageSize]="pageSize"
+        (page)="manejarCambioPaginado($event)"
+        [pageSizeOptions]="itemsPerPage"
+        showFirstLastButtons
+      ></mat-paginator>
     </div>
   </div>
 </ng-container>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
@@ -10,18 +10,14 @@ import { MatSort } from "@angular/material/sort";
 import { MatTableDataSource } from "@angular/material/table";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
-
 import { planMejoramientoConstructorTabla } from "./tabla-plan-mejoramiento.utilidades";
-
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
 import { AlertService } from "src/app/shared/services/alert.service";
 import { RolService } from "src/app/core/services/rol.service";
 import { UserService } from "src/app/core/services/user.service";
 import { environment } from "src/environments/environment";
-
 import { ModalAsignacionAuditoresComponent } from "./modal-asignacion-auditores/modal-asignacion-auditores.component";
-import { ModalVerDocumentosComponent } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
 
 @Component({
   selector: "app-tabla-plan-mejoramiento",
@@ -191,7 +187,7 @@ export class TablaPlanMejoramientoComponent implements OnInit {
   }
 
   registrarPlan(plan: any): void {
-    //this.router.navigate([`/planes/plan-mejoramiento/registrar-plan/${plan._id}`]);
+      this.router.navigate([`/plan-mejoramiento/registrar-plan/${plan._id}`]);
   }
 
   enviarAprobacion(plan: any): void {

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
@@ -1,25 +1,41 @@
-import { ChangeDetectorRef, Component, Input, ViewChild } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnInit,
+  ViewChild,
+} from "@angular/core";
 import { MatPaginator, PageEvent } from "@angular/material/paginator";
 import { MatSort } from "@angular/material/sort";
 import { MatTableDataSource } from "@angular/material/table";
-import { planMejoramientoConstructorTabla } from "./tabla-plan-mejoramiento.utilidades";
-import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { MatDialog } from "@angular/material/dialog";
 import { Router } from "@angular/router";
+
+import { planMejoramientoConstructorTabla } from "./tabla-plan-mejoramiento.utilidades";
+
+import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
+import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
 import { AlertService } from "src/app/shared/services/alert.service";
+import { RolService } from "src/app/core/services/rol.service";
+import { UserService } from "src/app/core/services/user.service";
 import { environment } from "src/environments/environment";
-import Swal from "sweetalert2";
+
+import { ModalAsignacionAuditoresComponent } from "./modal-asignacion-auditores/modal-asignacion-auditores.component";
+import { ModalVerDocumentosComponent } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
 
 @Component({
   selector: "app-tabla-plan-mejoramiento",
   templateUrl: "./tabla-plan-mejoramiento.component.html",
   styleUrls: ["./tabla-plan-mejoramiento.component.css"],
 })
-export class TablaPlanMejoramientoComponent {
+export class TablaPlanMejoramientoComponent implements OnInit {
   @Input() vigenciaId: any;
   @Input() tipoEvaluacionId: any;
   @Input() role: any;
+  @Input() personaId: any;
+
   @ViewChild(MatSort) sort!: MatSort;
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
 
   planesPorVigencia: any[] = [];
   planesDataSource: MatTableDataSource<any> = new MatTableDataSource();
@@ -27,118 +43,188 @@ export class TablaPlanMejoramientoComponent {
   banderaTablePlanes: boolean = false;
   tablaColumnas: any;
 
-  @ViewChild(MatPaginator) paginator!: MatPaginator;
   totalRegistros: number = 0;
   pageSize: number = 5;
   pageIndex: number = 0;
   itemsPerPage: number[] = [5, 10, 20];
 
+  usuarioId: number = 0;
+  cargoId: number = 0;
+  roles: string[] = [];
+
+  private tipoConsulta: "general" | "auditor" | "auditado" = "general";
+
+  readonly iconosAccion = new Map<string, string>([
+    ["Asignar Auditor(es)",       "manage_accounts"],
+    ["Registrar Plan",            "edit"],
+    ["Enviar a Revisión",         "send"],
+    ["Ver Documentos Auditoría",  "description"],
+  ]);
+
   constructor(
-    private alertaService: AlertService,
-    private changeDetector: ChangeDetectorRef,
-    private dialog: MatDialog,
-    private planAuditoriaMid: PlanAnualAuditoriaMid,
-    private router: Router
+    private readonly alertaService: AlertService,
+    private readonly changeDetector: ChangeDetectorRef,
+    private readonly dialog: MatDialog,
+    private readonly planAuditoriaMid: PlanAnualAuditoriaMid,
+    private readonly planAuditoriaService: PlanAnualAuditoriaService,
+    private readonly rolService: RolService,
+    private readonly userService: UserService,
+    private readonly router: Router
   ) {}
+
+  async ngOnInit() {
+    this.roles = this.rolService.getRoles();
+    this.usuarioId = await this.userService.getPersonaId();
+    this.configurarTipoConsulta();
+  }
+
+  private configurarTipoConsulta(): void {
+    if (this.rolService.tieneRol(environment.ROL.JEFE_DEPENDENCIA)) {
+      this.tipoConsulta = "auditado";
+      this.cargoId = environment.CARGO.JEFE_DEPENDENCIA_ID;
+    } else if (this.rolService.tieneRol(environment.ROL.ASISTENTE_DEPENDENCIA)) {
+      this.tipoConsulta = "auditado";
+      this.cargoId = environment.CARGO.ASISTENTE_DEPENDENCIA_ID;
+    } else if (
+      this.rolService.tieneRol(environment.ROL.AUDITOR) ||
+      this.rolService.tieneRol(environment.ROL.AUDITOR_ASISTENTE) ||
+      this.rolService.tieneRol(environment.ROL.AUDITOR_EXPERTO)
+    ) {
+      this.tipoConsulta = "auditor";
+    } else {
+      this.tipoConsulta = "general";
+    }
+  }
 
   listarPlanesPorFiltros(
     vigenciaId: number,
     tipoEvaluacionId: number,
-    limit: number = this.itemsPerPage[0],
+    limit: number = this.pageSize,
     offset: number = 0
-  ) {
-    console.log("Consultando auditorías - Rol:", this.role, "| Vigencia:", vigenciaId, "| Tipo:", tipoEvaluacionId);
-    
-    const estadoAprobadoInformeFinal = environment.AUDITORIA_ESTADO.EJECUCION.APROBADO_INFORME_FINAL_JEFE;
-    
+  ): void {
+    this.vigenciaId = vigenciaId;
+    this.tipoEvaluacionId = tipoEvaluacionId;
     this.planesPorVigencia = [];
 
-    this.planAuditoriaMid
-      .get(`auditoria?query=vigencia_id:${vigenciaId},tipo_evaluacion_id:${tipoEvaluacionId},estado_id:${estadoAprobadoInformeFinal},activo:true&limit=${limit}&offset=${offset}`)
-      .subscribe({
-        next: (res) => {
-          const auditorias: any[] = res.Data;
-          
-          // Verificar si hay datos
-          if (!auditorias || auditorias.length === 0) {
-            Swal.fire({
-              title: "No hay planes registrados",
-              text: `No se encontraron auditorías en estado "Aprobado informe final" para la vigencia y tipo de evaluación seleccionados.`,
-              icon: "info",
-            });
-            this.planesPorVigencia = [];
-            this.totalRegistros = 0;
-            this.banderaTablePlanes = false;
-            this.planesDataSource.data = [];
-            if (this.paginator) {
-              this.paginator.length = 0;
-            }
-            return;
-          }
-          
-          // Asignar datos y construir tabla
-          this.planesPorVigencia = auditorias;
-          this.totalRegistros = res.MetaData.Count;
-          this.banderaTablePlanes = true;
-          this.construirTabla();
-        },
-        error: (error) => {
-          console.error('Error al consultar auditorías:', error);
-          Swal.fire({
-            title: "Error",
-            text: "Ocurrió un error al consultar las auditorías. Por favor, intente nuevamente.",
-            icon: "error",
-          });
-          this.planesPorVigencia = [];
-          this.totalRegistros = 0;
-          this.banderaTablePlanes = false;
-          this.planesDataSource.data = [];
-          if (this.paginator) {
-            this.paginator.length = 0;
-          }
+    const baseQuery = `vigencia_id:${vigenciaId},tipo_evaluacion_id:${tipoEvaluacionId},activo:true`;
+    const endpoint = this.construirEndpoint(baseQuery, limit, offset);
+
+    this.planAuditoriaMid.get(endpoint).subscribe({
+      next: (res) => {
+        const auditorias: any[] = res?.Data ?? [];
+
+        if (!auditorias.length) {
+          this.alertaService.showAlert(
+            "Sin resultados",
+            "No se encontraron auditorías para la vigencia y tipo de evaluación seleccionados."
+          );
+          this.resetTabla();
+          return;
         }
-      });
+
+        this.planesPorVigencia = auditorias.map((auditoria: any) => {
+          const estadoId = auditoria.estado?.estado_id ?? auditoria.estado_id;
+          return {
+            ...auditoria,
+            acciones: this.getAccionesPorRolYEstado(estadoId),
+          };
+        });
+
+        this.totalRegistros = res?.MetaData?.Count ?? auditorias.length;
+        this.banderaTablePlanes = true;
+        this.construirTabla();
+      },
+      error: (error) => {
+        console.error("Error al consultar auditorías:", error);
+        this.alertaService.showErrorAlert(
+          "Ocurrió un error al consultar las auditorías. Por favor, intente nuevamente."
+        );
+        this.resetTabla();
+      },
+    });
   }
 
-  construirTabla() {
-    this.planesConstructorTabla = planMejoramientoConstructorTabla;
-    this.tablaColumnas = this.planesConstructorTabla.map((column: any) => column.columnDef);
-    this.planesDataSource = new MatTableDataSource(this.planesPorVigencia);
+  private construirEndpoint(baseQuery: string, limit: number, offset: number): string {
+    switch (this.tipoConsulta) {
+      case "auditado":
+        return `auditoria/auditado/${this.personaId}/${this.cargoId}?query=${baseQuery}&limit=${limit}&offset=${offset}`;
+      case "auditor":
+        return `auditoria/auditor/${this.personaId}?query=${baseQuery}&limit=${limit}&offset=${offset}`;
+      default:
+        return `auditoria?query=${baseQuery}&limit=${limit}&offset=${offset}`;
+    }
+  }
 
+  getAccionesPorRolYEstado(estadoId: number): string[] {
+
+    // para traer las acciones posterior del ./utils/accionesPorRolYEstado
+
+    if (true) {
+    return ["Asignar Auditor(es)", "Registrar Plan", "Enviar a Revisión", "Ver Documentos Auditoría"];
+    }
+  }
+
+  getIconoAccion(accion: string): string {
+    return this.iconosAccion.get(accion) ?? "help_outline";
+  }
+
+  realizarAccion(plan: any, accion: string): void {
+    const acciones: Record<string, () => void> = {
+      "Asignar Auditor(es)":      () => this.asignarAuditores(plan),
+      "Registrar Plan":           () => this.registrarPlan(plan),
+      "Enviar a Revisión":        () => this.enviarAprobacion(plan),
+      "Ver Documentos Auditoría": () => this.verDocumentosAuditoria(plan),
+    };
+    acciones[accion]?.();
+  }
+
+  asignarAuditores(plan: any): void {
+    const dialogRef = this.dialog.open(ModalAsignacionAuditoresComponent, {
+      width: "800px",
+      data: { auditoria: plan, usuarioId: this.usuarioId, role: this.role },
+    });
+    dialogRef.afterClosed().subscribe((guardado: boolean) => {
+      if (guardado) {
+        this.listarPlanesPorFiltros(this.vigenciaId, this.tipoEvaluacionId, this.pageSize, this.pageIndex * this.pageSize);
+      }
+    });
+  }
+
+  registrarPlan(plan: any): void {
+    //this.router.navigate([`/planes/plan-mejoramiento/registrar-plan/${plan._id}`]);
+  }
+
+  enviarAprobacion(plan: any): void {
+  }
+
+  verDocumentosAuditoria(plan: any): void {
+  }
+
+  private resetTabla(): void {
+    this.planesPorVigencia = [];
+    this.totalRegistros = 0;
+    this.banderaTablePlanes = false;
+    this.planesDataSource.data = [];
+    if (this.paginator) this.paginator.length = 0;
+  }
+
+  private construirTabla(): void {
+    this.planesConstructorTabla = planMejoramientoConstructorTabla;
+    this.tablaColumnas = this.planesConstructorTabla.map((c: any) => c.columnDef);
+    this.planesDataSource = new MatTableDataSource(this.planesPorVigencia);
     if (this.paginator) {
       this.planesDataSource.paginator = this.paginator;
       this.paginator.length = this.totalRegistros;
       this.paginator.pageSize = this.pageSize;
       this.paginator.pageIndex = this.pageIndex;
     }
-    if (this.sort) {
-      this.planesDataSource.sort = this.sort;
-    }
+    if (this.sort) this.planesDataSource.sort = this.sort;
     this.changeDetector.detectChanges();
   }
 
-  manejarCambioPaginado(evento: PageEvent) {
+  manejarCambioPaginado(evento: PageEvent): void {
     this.pageSize = evento.pageSize;
     this.pageIndex = evento.pageIndex;
-    const offset = this.pageIndex * this.pageSize;
-    this.listarPlanesPorFiltros(this.vigenciaId, this.tipoEvaluacionId, this.pageSize, offset);
-  }
-
-  registrarPlan(plan: any) {
-    this.router.navigate([`/planes/plan-mejoramiento/registrar-plan/${plan._id}`]);
-  }
-
-  enviarAprobacion(plan: any) {
-    this.alertaService
-      .showConfirmAlert("¿Está seguro de enviar el plan de mejoramiento para aprobación?")
-      .then((confirmado) => {
-        if (!confirmado.value) return;
-        console.log("Enviar aprobación plan:", plan);
-        this.alertaService.showSuccessAlert("Plan enviado exitosamente", "ENVIADO PARA APROBACIÓN");
-      });
-  }
-
-  verDocumentosAuditoria(plan: any) {
-    console.log("Ver documentos de auditoría:", plan);
+    this.listarPlanesPorFiltros(this.vigenciaId, this.tipoEvaluacionId, this.pageSize, this.pageIndex * this.pageSize);
   }
 }

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.utilidades.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.utilidades.ts
@@ -1,11 +1,62 @@
 export const planMejoramientoConstructorTabla = [
-  { columnDef: "numero",      header: "No.",           cell: (plan: any) => "",                    sortable: true  },
-  { columnDef: "vigencia",    header: "Vigencia",      cell: (plan: any) => plan.vigencia_nombre,  sortable: true  },
-  { columnDef: "auditoria",   header: "Auditoría",     cell: (plan: any) => plan.titulo,           sortable: true  },
-  { columnDef: "auditores",   header: "Auditor(es)",   cell: (plan: any) => plan.auditores_nombres,sortable: true  },
-  { columnDef: "dependencia", header: "Dependencia",   cell: (plan: any) => plan.dependencia_nombre,sortable: true },
-  { columnDef: "lider",       header: "Líder",         cell: (plan: any) => plan.lider_nombre,     sortable: true  },
-  { columnDef: "responsable", header: "Responsable",   cell: (plan: any) => plan.responsable_nombre,sortable: true },
-  { columnDef: "estado",      header: "Estado",        cell: (plan: any) => plan.estado_nombre,    sortable: true  },
-  { columnDef: "acciones",    header: "Acciones",      cell: (plan: any) => "",                    sortable: false },
+  {
+    columnDef: "numero",
+    header: "No.",
+    cell: (plan: any) => "",
+    sortable: false,
+  },
+  {
+    columnDef: "vigencia",
+    header: "Vigencia",
+    cell: (plan: any) => plan.vigencia_nombre,
+    sortable: true,
+  },
+  {
+    columnDef: "auditoria",
+    header: "Auditoría",
+    cell: (plan: any) => plan.titulo,
+    sortable: true,
+  },
+  {
+    columnDef: "tipo",
+    header: "Tipo",
+    cell: (plan: any) => plan.tipo_evaluacion_nombre,
+    sortable: true,
+  },
+  {
+    columnDef: "auditores_auditoria",
+    header: "Auditor(es) Responsable(s) Auditoría",
+    cell: (plan: any) =>
+      plan.auditores
+        ?.map((a: any) => a.auditor_nombre)
+        ?.join(", ") ?? "Sin auditor(es)",
+    sortable: false,
+  },
+  {
+    columnDef: "dependencia",
+    header: "Dependencia",
+    cell: (plan: any) => plan.dependencia_nombre,
+    sortable: true,
+  },
+  {
+    columnDef: "auditores_plan",
+    header: "Auditor(es) Responsable(s) Plan",
+    cell: (plan: any) =>
+      plan.auditores_plan?.length
+        ? plan.auditores_plan.map((a: any) => a.nombre).join(", ")
+        : "Sin Auditor(es)",
+    sortable: false,
+  },
+  {
+    columnDef: "estado",
+    header: "Estado",
+    cell: (plan: any) => plan.estado_nombre ?? plan.estado?.estado_nombre,
+    sortable: true,
+  },
+  {
+    columnDef: "acciones",
+    header: "Acciones",
+    cell: (plan: any) => "",
+    sortable: false,
+  },
 ];

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.html
@@ -1,5 +1,8 @@
-<plantilla-tarjeta-contenedora [title]="'Plan de Mejoramiento'"
-  [breadcrumb]="'<p>Gestión de Planes / <b>Plan de Mejoramiento</b></p>'" [contenido]="contenidoDePlantilla">
+<plantilla-tarjeta-contenedora
+  [title]="'Plan de Mejoramiento'"
+  [breadcrumb]="'<p>Gestión de Planes / <b>Plan de Mejoramiento</b></p>'"
+  [contenido]="contenidoDePlantilla"
+>
 </plantilla-tarjeta-contenedora>
 
 <ng-template #contenidoDePlantilla>
@@ -12,24 +15,38 @@
           <mat-form-field class="col-md-4 col-12 mt-4" appearance="outline">
             <mat-label>Vigencia</mat-label>
             <mat-icon color="primary" matPrefix>today</mat-icon>
-            <mat-select formControlName="vigencia" (selectionChange)="onVigenciaChange($event.value)" color="primary">
+            <mat-select
+              formControlName="vigencia"
+              (selectionChange)="onVigenciaChange($event.value)"
+              color="primary"
+            >
               <mat-option disabled value="">--Seleccionar--</mat-option>
-              <mat-option *ngFor="let vigencia of vigencias" [value]="vigencia">{{ vigencia.Nombre }}</mat-option>
+              <mat-option *ngFor="let vigencia of vigencias" [value]="vigencia">
+                {{ vigencia.Nombre }}
+              </mat-option>
             </mat-select>
           </mat-form-field>
 
-          <!-- TEXTO: Seleccione la vigencia a consultar -->
+          <!-- TEXTO: instrucción -->
           <div class="col-md-2 col-12 d-flex align-items-center mt-4">
-            <p style="font-size: 14px; margin-bottom: 0;">Seleccione la vigencia a consultar</p>
+            <p style="font-size: 14px; margin-bottom: 0">
+              Seleccione la vigencia a consultar
+            </p>
           </div>
 
           <!-- FILTRO: TIPO DE EVALUACIÓN -->
           <mat-form-field class="col-md-4 col-12 mt-4" appearance="outline">
             <mat-label>Tipo de Evaluación</mat-label>
             <mat-icon color="primary" matPrefix>assessment</mat-icon>
-            <mat-select formControlName="tipoEvaluacion" (selectionChange)="onTipoEvaluacionChange($event.value)" color="primary">
+            <mat-select
+              formControlName="tipoEvaluacion"
+              (selectionChange)="onTipoEvaluacionChange($event.value)"
+              color="primary"
+            >
               <mat-option disabled value="">--Seleccionar--</mat-option>
-              <mat-option *ngFor="let tipo of tiposEvaluacion" [value]="tipo">{{ tipo.Nombre }}</mat-option>
+              <mat-option *ngFor="let tipo of tiposEvaluacion" [value]="tipo">
+                {{ tipo.Nombre }}
+              </mat-option>
             </mat-select>
           </mat-form-field>
 
@@ -41,7 +58,12 @@
   <!-- TABLA DE PLANES DE MEJORAMIENTO -->
   <div class="row">
     <div class="col-12">
-      <app-tabla-plan-mejoramiento [vigenciaId]="vigenciaSeleccionada" [tipoEvaluacionId]="tipoEvaluacionSeleccionado"></app-tabla-plan-mejoramiento>
+      <app-tabla-plan-mejoramiento
+        [vigenciaId]="vigenciaSeleccionada"
+        [tipoEvaluacionId]="tipoEvaluacionSeleccionado"
+        [role]="role"
+        [personaId]="personaId"
+      ></app-tabla-plan-mejoramiento>
     </div>
   </div>
 </ng-template>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.ts
@@ -3,12 +3,14 @@ import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { Vigencia } from "src/app/shared/data/models/vigencia.model";
 import { ParametrosUtilsService } from "src/app/shared/services/parametros.service";
 import { TablaPlanMejoramientoComponent } from "./ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component";
-import { ImplicitAutenticationService } from "src/app/core/services/implicit_autentication.service";
+import { RolService } from "src/app/core/services/rol.service";
+import { UserService } from "src/app/core/services/user.service";
+import { environment } from "src/environments/environment";
 
 @Component({
   selector: "app-plan-de-mejoramiento",
   templateUrl: "./plan-mejoramiento.component.html",
-  styleUrls: ["./plan-mejoramiento.component.css"]
+  styleUrls: ["./plan-mejoramiento.component.css"],
 })
 export class PlanDeMejoramientoComponent implements OnInit {
   @ViewChild(TablaPlanMejoramientoComponent)
@@ -20,47 +22,66 @@ export class PlanDeMejoramientoComponent implements OnInit {
   vigenciaSeleccionada!: number;
   tipoEvaluacionSeleccionado!: number;
 
+  /** Rol prioritario del usuario actual */
+  role: string | null = null;
+  /** ID de persona del usuario actual */
+  personaId: number | null = null;
+
   constructor(
-    private fb: FormBuilder,
-    private parametrosUtilsService: ParametrosUtilsService,
-    private autenticacionService: ImplicitAutenticationService,
+    private readonly fb: FormBuilder,
+    private readonly parametrosUtilsService: ParametrosUtilsService,
+    private readonly rolService: RolService,
+    private readonly userService: UserService
   ) {}
 
-  ngOnInit() {
+  async ngOnInit() {
     this.iniciarForm();
     this.cargarVigencias();
     this.cargarTiposEvaluacion();
+    this.obtenerRolPrioritario();
+    this.personaId = await this.userService.getPersonaId();
   }
 
-  cargarVigencias() {
+  obtenerRolPrioritario(): void {
+    this.role = this.rolService.getRolPrioritario([
+      environment.ROL.JEFE,
+      environment.ROL.AUDITOR_EXPERTO,
+      environment.ROL.AUDITOR,
+      environment.ROL.AUDITOR_ASISTENTE,
+      environment.ROL.JEFE_DEPENDENCIA,
+      environment.ROL.ASISTENTE_DEPENDENCIA,
+    ]);
+  }
+
+  cargarVigencias(): void {
     this.parametrosUtilsService.getVigencias().subscribe({
       next: (data) => {
         this.vigencias = data;
       },
       error: (err) => {
-        console.error("Error load vigencias", err);
-      }
+        console.error("Error cargando vigencias:", err);
+      },
     });
   }
 
-  cargarTiposEvaluacion() {
+  cargarTiposEvaluacion(): void {
+    // Tipos de evaluación relevantes para plan de mejoramiento
     this.tiposEvaluacion = [
-      { Id: 1, Nombre: "Interna" },
-      { Id: 2, Nombre: "Externa" }
+      { Id: environment.TIPO_EVALUACION.AUDITORIA_INTERNA_ID, Nombre: "Auditoría Interna" },
     ];
   }
 
-  onVigenciaChange(vigencia: Vigencia) {
+  onVigenciaChange(vigencia: Vigencia): void {
     this.vigenciaSeleccionada = vigencia.Id;
     this.buscarPlanes();
   }
 
-  onTipoEvaluacionChange(tipoEvaluacion: any) {
+  onTipoEvaluacionChange(tipoEvaluacion: any): void {
     this.tipoEvaluacionSeleccionado = tipoEvaluacion.Id;
     this.buscarPlanes();
   }
 
-  buscarPlanes() {
+  buscarPlanes(): void {
     if (this.vigenciaSeleccionada && this.tipoEvaluacionSeleccionado) {
       this.tablaPlanMejoramiento.listarPlanesPorFiltros(
         this.vigenciaSeleccionada,
@@ -69,7 +90,7 @@ export class PlanDeMejoramientoComponent implements OnInit {
     }
   }
 
-  iniciarForm() {
+  iniciarForm(): void {
     this.planMejoramientoForm = this.fb.group({
       vigencia: ["", Validators.required],
       tipoEvaluacion: ["", Validators.required],

--- a/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
+++ b/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
@@ -1,11 +1,16 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { PlanDeMejoramientoComponent } from './components/plan-de-mejoramiento/plan-mejoramiento.component';
+import { RegistrarPlanComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component';
 
 const routes: Routes = [
   {
-    path: 'plan-mejoramiento',
+    path: '',
     component: PlanDeMejoramientoComponent,
+  },
+  {
+    path: 'registrar-plan/:id',
+    component: RegistrarPlanComponent,
   },
 ];
 

--- a/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
+++ b/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
@@ -5,12 +5,12 @@ import { PlanDeMejoramientoComponent } from './components/plan-de-mejoramiento/p
 const routes: Routes = [
   {
     path: 'plan-mejoramiento',
-    component: PlanDeMejoramientoComponent
-  }
+    component: PlanDeMejoramientoComponent,
+  },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
-export class PlanesRoutingModule { }
+export class PlanesRoutingModule {}

--- a/src/app/modules/plan-mejoramiento/plan-mejoramiento.module.ts
+++ b/src/app/modules/plan-mejoramiento/plan-mejoramiento.module.ts
@@ -13,21 +13,27 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
 import { PlanesRoutingModule } from './plan-mejoramiento-routing.module';
+import { SharedModule } from '../../shared/shared.module';
+
 import { PlanDeMejoramientoComponent } from './components/plan-de-mejoramiento/plan-mejoramiento.component';
 import { TablaPlanMejoramientoComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component';
-import { SharedModule } from '../../shared/shared.module';
+import { ModalAsignacionAuditoresComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component';
 
 @NgModule({
   declarations: [
     PlanDeMejoramientoComponent,
     TablaPlanMejoramientoComponent,
+    ModalAsignacionAuditoresComponent,
   ],
   imports: [
     CommonModule,
     ReactiveFormsModule,
-    SharedModule,
     FormsModule,
+    SharedModule,
     PlanesRoutingModule,
     MatFormFieldModule,
     MatInputModule,
@@ -41,6 +47,8 @@ import { SharedModule } from '../../shared/shared.module';
     MatTooltipModule,
     MatCardModule,
     MatDividerModule,
-  ]
+    MatDialogModule,
+    MatProgressSpinnerModule,
+  ],
 })
-export class PlanesModule { }
+export class PlanesModule {}

--- a/src/app/modules/plan-mejoramiento/plan-mejoramiento.module.ts
+++ b/src/app/modules/plan-mejoramiento/plan-mejoramiento.module.ts
@@ -22,12 +22,18 @@ import { SharedModule } from '../../shared/shared.module';
 import { PlanDeMejoramientoComponent } from './components/plan-de-mejoramiento/plan-mejoramiento.component';
 import { TablaPlanMejoramientoComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component';
 import { ModalAsignacionAuditoresComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/modal-asignacion-auditores/modal-asignacion-auditores.component';
+import { RegistrarPlanComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component';
+import { TablaHallazgosComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component';
+import { ModalRegistrarAccionComponent } from './components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component';
 
 @NgModule({
   declarations: [
     PlanDeMejoramientoComponent,
     TablaPlanMejoramientoComponent,
     ModalAsignacionAuditoresComponent,
+    RegistrarPlanComponent,
+    TablaHallazgosComponent,
+    ModalRegistrarAccionComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
Se implementa la base del módulo de plan de mejoramiento cubriendo la consulta y visualización de auditorías, asignación de auditores, registro de planes y formulación de acciones sobre hallazgos.

## Cambios principales

### Consulta de auditorías por rol
- Se determina el tipo de consulta (`general`, `auditor`, `auditado`) en `configurarTipoConsulta()` según el rol del usuario via `RolService`.
- La URL se construye en `construirEndpoint()` filtrando por `vigencia_id`, `tipo_evaluacion_id` y `activo:true`, con soporte de paginación (`limit`, `offset`).
- Cada auditoría retornada se enriquece con su arreglo `acciones[]` antes de pasarla al datasource.

### Modal de asignación de auditores
- Secciones: información de la auditoría (read-only), cronograma, auditores de la auditoría (read-only) y auditores del plan (editable con agregar/eliminar).
- Carga paralela con `forkJoin` de auditores ya asignados (`auditoria-auditor`) y disponibles (`autenticacionMidService`), deduplicados con `Map` y filtrados por rol auditor.
- El spinner se localiza únicamente en el `mat-select` para no bloquear el renderizado del resto del modal; se difiere con `setTimeout(0)` hasta después del primer render.
- Al cerrarse con `guardado: true` recarga la tabla conservando la paginación actual.

### Menú de acciones dinámico
- Las acciones se iteran desde `row.acciones[]` y se despachan mediante `realizarAccion()` usando un `Record<string, () => void>`, permitiendo extender acciones sin modificar el template.

### Vista de registro de plan
- `registrarPlan()` navega a `/plan-mejoramiento/registrar-plan/:id` usando el `_id` de la auditoría.
- `RegistrarPlanComponent` carga la auditoría desde `auditoria/:id` y la propaga como `[auditoria]` y `[auditoriaId]` al componente hijo `app-tabla-hallazgos`.
- Vista con sección read-only de información del plan y footer con acciones: Vista Previa, Guardar y Enviar a Auditor.

### Consulta jerárquica de hallazgos
- Carga en dos pasos: primero obtiene el `informeId` desde `informe?query=auditoria_id:X,activo:true`, luego recorre `tema → subtema → hallazgo` construyendo el índice compuesto `temaCount.subtemaCount.hallazgoCount`.
- El campo `criterio` del backend se mapea al campo `causa` del modelo local `HallazgoTabla`.
- `reconstruirFilas()` aplana la jerarquía en un datasource plano usando el flag `esGrupo: boolean` para alternar entre la columna `grupo` (cabecera expandible con `colspan`) y las columnas de detalle de acción.
- El estado de expansión y acciones locales se preservan entre recargas mediante un `Map<hallazgoId, { expandido, acciones }>`.

### Modal de registro y edición de acciones
- `FormGroup` reactivo con campos `causa`, `tipoAccion`, `accionPlanteada` (requeridos) y `nombreIndicador`, `formulaIndicador`, `meta` (opcionales).
- Modo edición determinado por `modoEdicion = !!data.accion`; si hay acción existente se puebla el formulario con `patchValue()`.
- Tooltips contextuales por campo definidos en `readonly tooltips`; el tooltip de `tipoAccion` es dinámico según el valor seleccionado (`accionPreventiva` / `accionCorrectiva`).
- Gestión de responsables con validación de duplicados via `Array.some()`, moviendo elementos entre el selector y `responsablesAgregados` en ambas direcciones.
- Al cerrar con `dialogRef.close(accionGuardada)`, `tabla-hallazgos` actualiza la acción en su posición original (edición) o la agrega con `numero` autogenerado forzando `expandido: true` (creación).

---