### PR TITLE
feat: implementación de encabezados de vigencia y jerarquía título-subtítulo en formularios udistrital/sisifo_documentacion#696

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.html
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.html
@@ -1,5 +1,7 @@
 <plantilla-tarjeta-contenedora
   [title]="'Editar Auditoría'"
+  [subtitle]="auditoria.vigencia_nombre || ''"
+  [subtitleChild]="auditoria.titulo || ''"
   [breadcrumb]="
     '<p>Gestión Auditoría / Planeación / Auditorías Internas / <b>Editar Auditoría</b></p>'
   "

--- a/src/app/shared/elements/templates/plantilla-tarjeta-contenedora/plantilla-tarjeta-contenedora.component.html
+++ b/src/app/shared/elements/templates/plantilla-tarjeta-contenedora/plantilla-tarjeta-contenedora.component.html
@@ -6,13 +6,15 @@
   </div>
   <mat-card class="p-3">
     <mat-card-content>
-      <div class="d-flex justify-content-between my-2">
-        <h4 *ngIf="subtitle" class="text-primary mb-3">
-          <mat-icon class="align-middle">calendar_today</mat-icon>
-          Vigencia {{ subtitle }}
-        </h4>
+      <div class="d-flex align-items-center gap-2 my-1" *ngIf="subtitle">
+        <mat-icon color="primary">calendar_today</mat-icon>
+        <b>Vigencia {{ subtitle }}</b>
       </div>
-      <div class="d-flex justify-content-between my-2">
+      <div class="d-flex align-items-center gap-2 my-1" *ngIf="subtitleChild">
+        <mat-icon color="primary">bookmark</mat-icon>
+        <b>{{ subtitleChild }}</b>
+      </div>
+      <div class="d-flex justify-content-between align-items-center my-2">
         <h2 style="color: var(--md-primary-700)">{{ title }}</h2>
         <button
           *ngIf="mostrarBotonRegresar"
@@ -24,7 +26,6 @@
           <mat-icon>toll</mat-icon>Regresar
         </button>
       </div>
-      <!-- Renderiza el template proporcionado -->
       <ng-container *ngTemplateOutlet="contenido"></ng-container>
     </mat-card-content>
   </mat-card>

--- a/src/app/shared/elements/templates/plantilla-tarjeta-contenedora/plantilla-tarjeta-contenedora.component.ts
+++ b/src/app/shared/elements/templates/plantilla-tarjeta-contenedora/plantilla-tarjeta-contenedora.component.ts
@@ -38,6 +38,8 @@ export class PlantillaTarjetaContenedoraComponent {
    */
    @Input() subtitle: string = "";
 
+   @Input() subtitleChild: string = "";
+
 
   /**
    * Contenido dinámico que será renderizado dentro de la tarjeta.


### PR DESCRIPTION
## Implementación de encabezados en Editar Auditoría

Se agregó el `@Input() subtitleChild` en `plantilla-tarjeta-contenedora` para soportar el título de la auditoría como segundo encabezado. En `editar-auditoria.component.html` se pasan `auditoria.vigencia_nombre` y `auditoria.titulo` a la plantilla para mostrar la vigencia y el título del registro que se está editando.