### PR TITLE
feat: ajuste de altura de campos de texto en primer paso de planeación

### DIFF
--- a/src/app/modules/ejecucion/components/auditorias-internas/editar-informe/editar-informe.utilidades.ts
+++ b/src/app/modules/ejecucion/components/auditorias-internas/editar-informe/editar-informe.utilidades.ts
@@ -108,6 +108,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "alcance_auditoria",
@@ -117,6 +118,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "criterios",
@@ -126,6 +128,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "muestra",

--- a/src/app/modules/ejecucion/components/auditorias-internas/editar-informe/editar-informe.utilidades.ts
+++ b/src/app/modules/ejecucion/components/auditorias-internas/editar-informe/editar-informe.utilidades.ts
@@ -108,7 +108,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "alcance_auditoria",
@@ -118,7 +118,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "criterios",
@@ -128,7 +128,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "muestra",

--- a/src/app/modules/ejecucion/components/seguimiento-informes/editar-informe-seguimiento/editar-informe-seguimiento.utilidades.ts
+++ b/src/app/modules/ejecucion/components/seguimiento-informes/editar-informe-seguimiento/editar-informe-seguimiento.utilidades.ts
@@ -99,7 +99,6 @@ export const formularioInformacionSeguimiento: Formulario = {
       tipo: "date",
       claseGrid: "col-lg-4 col-md-6 col-sm-12 col-xs-12",
     },
-    // TODO: La vista de planeación de informes y seguimiento no tiene estos campos, revisar su pertinencia.
     {
       nombre: "objetivo_auditoria",
       etiqueta: "Objetivo de la Auditoría",
@@ -108,7 +107,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "alcance_auditoria",
@@ -118,7 +117,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "criterios",
@@ -128,7 +127,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "muestra",

--- a/src/app/modules/ejecucion/components/seguimiento-informes/editar-informe-seguimiento/editar-informe-seguimiento.utilidades.ts
+++ b/src/app/modules/ejecucion/components/seguimiento-informes/editar-informe-seguimiento/editar-informe-seguimiento.utilidades.ts
@@ -99,6 +99,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       tipo: "date",
       claseGrid: "col-lg-4 col-md-6 col-sm-12 col-xs-12",
     },
+    // TODO: La vista de planeación de informes y seguimiento no tiene estos campos, revisar su pertinencia.
     {
       nombre: "objetivo_auditoria",
       etiqueta: "Objetivo de la Auditoría",
@@ -107,6 +108,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "alcance_auditoria",
@@ -116,6 +118,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "criterios",
@@ -125,6 +128,7 @@ export const formularioInformacionSeguimiento: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: true,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "muestra",

--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.utilidades.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.utilidades.ts
@@ -85,6 +85,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "alcance_auditoria",
@@ -94,6 +95,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
     {
       nombre: "criterios",
@@ -103,6 +105,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 150 },
     },
   ],
 };

--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.utilidades.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.utilidades.ts
@@ -85,7 +85,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "alcance_auditoria",
@@ -95,7 +95,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
     {
       nombre: "criterios",
@@ -105,7 +105,7 @@ export const formularioInformacionAuditoria: Formulario = {
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 150 },
+      parametros: { altura: 120 },
     },
   ],
 };

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
@@ -177,11 +177,14 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
       return correo;
     });
     return {
+      alcance: informacion.alcance_auditoria,
       consecutivo_IE: informacion.consecutivo_IE,
       consecutivo_OCI: informacion.consecutivo_OCI,
+      criterio: informacion.criterios,
       fecha_fin: informacion.fecha_ejecucion_final,
       fecha_inicio: informacion.fecha_ejecucion_inicial,
       consecutivo_no_auditoria: informacion.consecutivo_no_auditoria,
+      objetivo: informacion.objetivo_auditoria,
       correo_complementario: correos,
     };
   }

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.utilidades.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.utilidades.ts
@@ -76,6 +76,36 @@ export const formularioInformacionAuditoria: Formulario = {
       tipo: "date",
       claseGrid: "col-lg-6 col-md-6 col-sm-12 col-xs-12",
     },
+    {
+      nombre: "objetivo_auditoria",
+      etiqueta: "Objetivo de la Auditoría",
+      icono: "flag",
+      tipo: "textarea",
+      validaciones: [{ tipo: "requerido", valor: "" }],
+      deshabilitado: false,
+      claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 120 },
+    },
+    {
+      nombre: "alcance_auditoria",
+      etiqueta: "Alcance de la Auditoría",
+      icono: "visibility",
+      tipo: "textarea",
+      validaciones: [{ tipo: "requerido", valor: "" }],
+      deshabilitado: false,
+      claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 120 },
+    },
+    {
+      nombre: "criterios",
+      etiqueta: "Criterios",
+      icono: "check_circle",
+      tipo: "textarea",
+      validaciones: [{ tipo: "requerido", valor: "" }],
+      deshabilitado: false,
+      claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      parametros: { altura: 120 },
+    },
   ],
 };
 
@@ -138,6 +168,5 @@ export const formularioDependencias: Formulario = {
       deshabilitado: false,
       claseGrid: "col-lg-6 col-md-6 col-sm-12 col-xs-12",
     },
-    // TODO: La vista de ejecución de informes y seguimiento no tiene estos campos, revisar su pertinencia.
   ]
 }

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.utilidades.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.utilidades.ts
@@ -138,6 +138,6 @@ export const formularioDependencias: Formulario = {
       deshabilitado: false,
       claseGrid: "col-lg-6 col-md-6 col-sm-12 col-xs-12",
     },
+    // TODO: La vista de ejecución de informes y seguimiento no tiene estos campos, revisar su pertinencia.
   ]
 }
-

--- a/src/app/shared/data/models/formulario.model.ts
+++ b/src/app/shared/data/models/formulario.model.ts
@@ -35,6 +35,7 @@ export class Campo {
     fecha_inicio?: string;
     etiqueta_inicio?: string;
     etiqueta_fin?: string;
+    altura?: number;
   };
   deshabilitado?: boolean;
   valor?: any;

--- a/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.html
+++ b/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.html
@@ -124,7 +124,6 @@
         <mat-icon *ngIf="campo.icono" matPrefix>{{ campo.icono }}</mat-icon>
         <textarea
           matInput
-          style="resize: none"
           [style.height.px]="campo.parametros?.altura || 72"
           [formControlName]="campo.nombre"
           [placeholder]="campo.placeholder || ''"

--- a/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.html
+++ b/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.html
@@ -122,8 +122,13 @@
       <mat-form-field *ngSwitchCase="'textarea'" appearance="outline" class="example-full-width">
         <mat-label>{{ campo.etiqueta }}</mat-label>
         <mat-icon *ngIf="campo.icono" matPrefix>{{ campo.icono }}</mat-icon>
-        <textarea style="height: 72px; resize: none" matInput [formControlName]="campo.nombre"
-          [placeholder]="campo.placeholder || ''"></textarea>
+        <textarea
+          matInput
+          style="resize: none"
+          [style.height.px]="campo.parametros?.altura || 72"
+          [formControlName]="campo.nombre"
+          [placeholder]="campo.placeholder || ''"
+        ></textarea>
         <mat-error *ngIf="form.controls[campo.nombre].hasError('required')">
           {{ campo.etiqueta }} es requerido
         </mat-error>


### PR DESCRIPTION
This pull request introduces improvements to the dynamic form system by allowing the height of textarea fields to be customized via a new `altura` parameter. It also ensures that audit-related forms consistently use this parameter for relevant fields, and updates the data model and form rendering logic to support these changes. Additionally, new fields are added to the seguimiento (tracking) form, and the mapping logic is updated accordingly.

Ansers:
- udistrital/sisifo_documentacion#693

**Dynamic Form Improvements**

* Added an optional `altura` (height) property to the `Campo` model's `parametros` object, enabling dynamic control of textarea height in forms. (`formulario.model.ts`)
* Updated the dynamic form component template to set the height of textarea elements based on the `altura` parameter, defaulting to 72px if not specified. (`formulario-dinamico.component.html`)

**Form Field Enhancements**

* Added the `parametros: { altura: 120 }` property to the `objetivo_auditoria`, `alcance_auditoria`, `criterios`, and `muestra` fields in multiple form definitions to standardize textarea height. (`editar-informe.utilidades.ts`, `editar-informe-seguimiento.utilidades.ts`, `editar-auditoria.utilidades.ts`) [[1]](diffhunk://#diff-d5fd98b731913715318d90e704c3e43a4e173eb61dce8b5e7f1618f55f5611e2R111) [[2]](diffhunk://#diff-d5fd98b731913715318d90e704c3e43a4e173eb61dce8b5e7f1618f55f5611e2R121) [[3]](diffhunk://#diff-d5fd98b731913715318d90e704c3e43a4e173eb61dce8b5e7f1618f55f5611e2R131) [[4]](diffhunk://#diff-23bc526a741e3c0adc0ebf178b3d57e75c8139c15d306886113f060900ab3d00R110) [[5]](diffhunk://#diff-23bc526a741e3c0adc0ebf178b3d57e75c8139c15d306886113f060900ab3d00R120) [[6]](diffhunk://#diff-23bc526a741e3c0adc0ebf178b3d57e75c8139c15d306886113f060900ab3d00R130) [[7]](diffhunk://#diff-272d677718cb7895987a95038f0c325cb3cc6a78457ee94b6fd81de25135f841R88) [[8]](diffhunk://#diff-272d677718cb7895987a95038f0c325cb3cc6a78457ee94b6fd81de25135f841R98) [[9]](diffhunk://#diff-272d677718cb7895987a95038f0c325cb3cc6a78457ee94b6fd81de25135f841R108)

**Seguimiento Form Expansion**

* Introduced new fields (`objetivo_auditoria`, `alcance_auditoria`, and `criterios`) with textarea inputs and custom height to the seguimiento form definition. (`editar-seguimiento.utilidades.ts`)

**Form Data Mapping Update**

* Updated the data mapping logic in the `EditarSeguimientoComponent` to include the new fields (`alcance`, `criterio`, and `objetivo`) when processing form data. (`editar-seguimiento.component.ts`)