### PR TITLE
fix: La UI ya no permite repetir auditores en asignación de auditorías

### DIFF
--- a/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.html
+++ b/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.html
@@ -83,7 +83,7 @@
                   label="Auditor"
                   icon="person"
                   placeholder="Seleccione un auditor"
-                  [items]="auditores"
+                  [items]="auditoresDisponibles(i)"
                   [labelKey]="'nombre'"
                   [selectionControl]="getAuditorControl(i)"
                 ></app-search-selection>

--- a/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.ts
+++ b/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.ts
@@ -1,6 +1,7 @@
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { AutenticacionMidService } from "src/app/core/services/autenticacion-mid.service";
-import { Component, Inject, OnInit } from "@angular/core";
+import { Component, Inject, OnInit, OnDestroy } from "@angular/core";
+import { Subscription } from 'rxjs';
 import { FormArray, FormBuilder, FormControl, FormGroup } from "@angular/forms";
 import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
 import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
@@ -22,6 +23,8 @@ export class ModalAgregarAuditorComponent implements OnInit {
   auditores: Auditor[] = [];
   auditoresSeleccionados: FormArray<FormGroup>;
   auditoresAsignados: Auditor[] = [];
+  auditoresDisponiblesCache: Auditor[][] = [];
+  private selectionChangesSub: Subscription | null = null;
   meses: Parametro[] = [];
   TODOS = "Todos";
   isEditMode = false;
@@ -92,6 +95,9 @@ export class ModalAgregarAuditorComponent implements OnInit {
         console.error("Error al cargar auditores asignados:", error);
       }
     });
+    // Inicializar caché y suscripciones tras poblar los controles
+    this.recomputeAuditoresDisponibles();
+    this.subscribeToSelectionChanges();
   }
 
   agregarAuditor() {
@@ -101,6 +107,7 @@ export class ModalAgregarAuditorComponent implements OnInit {
         lider: this.fb.control<boolean>(false),
       })
     );
+    this.recomputeAuditoresDisponibles();
   }
 
   eliminarAuditor(index: number) {
@@ -128,6 +135,7 @@ export class ModalAgregarAuditorComponent implements OnInit {
                   this.alertaService.showSuccessAlert(
                     "Auditor eliminado correctamente."
                   );
+                  this.recomputeAuditoresDisponibles();
                 },
                 error: (err) => {
                   this.alertaService.showErrorAlert(
@@ -140,6 +148,7 @@ export class ModalAgregarAuditorComponent implements OnInit {
             this.alertaService.showSuccessAlert(
               "Auditor eliminado correctamente."
             );
+            this.recomputeAuditoresDisponibles();
           }
         }
       });
@@ -172,13 +181,70 @@ export class ModalAgregarAuditorComponent implements OnInit {
   }
 
   auditoresDisponibles(index: number): Auditor[] {
-    const seleccionados = this.auditoresSeleccionados.value
-      .filter((_, i) => i !== index)
-      .map((control: { auditor: Auditor }) => control.auditor?.documento);
+    return this.auditoresDisponiblesCache[index] ?? this.auditores;
+  }
 
-    return this.auditores.filter(
-      (auditor) => !seleccionados.includes(auditor.documento)
-    );
+  private subscribeToSelectionChanges(): void {
+    if (this.selectionChangesSub) {
+      this.selectionChangesSub.unsubscribe();
+    }
+    if (this.auditoresSeleccionados) {
+      this.selectionChangesSub = this.auditoresSeleccionados.valueChanges.subscribe(() => {
+        this.recomputeAuditoresDisponibles();
+      });
+    }
+  }
+
+  private recomputeAuditoresDisponibles(): void {
+    if (!this.auditores || !this.auditoresSeleccionados) {
+      return;
+    }
+
+    const controls = this.auditoresSeleccionados.controls || [];
+    const newCache: Auditor[][] = [];
+
+    for (let i = 0; i < controls.length; i++) {
+      const seleccionados = controls
+        .filter((_, idx) => idx !== i)
+        .map((control) => control.get('auditor')?.value?.documento)
+        .filter((d: any) => d != null);
+
+      newCache[i] = this.auditores.filter(
+        (auditor) => !seleccionados.includes(auditor.documento)
+      );
+    }
+
+    // Update cache only where changed to keep stable references
+    const maxLen = Math.max(this.auditoresDisponiblesCache.length, newCache.length);
+    for (let i = 0; i < maxLen; i++) {
+      const oldArr = this.auditoresDisponiblesCache[i] || [];
+      const newArr = newCache[i] || [];
+      if (!this.areAuditorArraysEqual(oldArr, newArr)) {
+        this.auditoresDisponiblesCache[i] = newArr;
+      }
+    }
+
+    // truncate if needed
+    if (newCache.length < this.auditoresDisponiblesCache.length) {
+      this.auditoresDisponiblesCache.length = newCache.length;
+    }
+  }
+
+  private areAuditorArraysEqual(a: Auditor[], b: Auditor[]): boolean {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (a[i].id !== b[i].id) return false;
+    }
+    return true;
+  }
+
+  ngOnDestroy(): void {
+    if (this.selectionChangesSub) {
+      this.selectionChangesSub.unsubscribe();
+      this.selectionChangesSub = null;
+    }
   }
 
   onLiderChange(selectedIndex: number): void {


### PR DESCRIPTION
This pull request improves the handling of available auditors in the `ModalAgregarAuditorComponent` to ensure that each selection dropdown only shows auditors who have not already been selected in other rows. The main changes introduce a caching mechanism for available auditors per row, automatic updates when selections change, and proper cleanup of subscriptions.

Answers:

- udistrital/sisifo_documentacion#714

**Auditor selection logic improvements:**

* Replaced the static `auditores` list with a dynamic method `auditoresDisponibles(i)` in the template, so each dropdown only shows auditors not already selected in other rows.
* Added a per-row cache (`auditoresDisponiblesCache`) and a method `recomputeAuditoresDisponibles()` to efficiently recalculate available auditors whenever selections change, or when auditors are added/removed. [[1]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR26-R27) [[2]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcL175-R249)
* Subscribed to selection changes (`FormArray.valueChanges`) to automatically update the available auditors for each dropdown when any selection is modified, and unsubscribed on destroy to prevent memory leaks.
* Updated logic to recalculate available auditors after adding or removing auditors, ensuring the UI always reflects the current state. [[1]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR110) [[2]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR138) [[3]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR151) [[4]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcR98-R100)

**Code maintenance:**

* Implemented `OnDestroy` and managed the subscription lifecycle to avoid memory leaks. [[1]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcL3-R4) [[2]](diffhunk://#diff-2a434af164dfef363ba9c801f0c0c6749f49dbd34a5a6931a51623481d1097bcL175-R249)