### PR TITLE
feat: Solicitud de Información planeación seguimiento 

### DIFF
--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.html
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.html
@@ -44,8 +44,23 @@
               [formulario]="formularioInformacion"
               (submitFormulario)="preguntarGuardadoInformacion($event)"
               (campoSeleccionado)="manejarCambioSelect($event)"
-            >
-            </app-formulario-dinamico>
+            ></app-formulario-dinamico>
+            <div class="d-flex align-items-center fondo-acento-50 my-3">
+              <div>
+                <mat-icon>memory</mat-icon>
+              </div>
+              <div class="mx-3">
+                <h2>Solicitud de Información</h2>
+                Información para la ejecución de la auditoría
+              </div>
+            </div>
+            <div *ngIf="formularioTemas != null" class="mt-4">
+              <app-formulario-dinamico
+                #formularioTemasComp
+                [formulario]="formularioTemas"
+                >
+              </app-formulario-dinamico>
+            </div>
             <div class="d-flex align-items-center fondo-acento-50 my-3">
               <div>
                 <mat-icon>assignment</mat-icon>

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
@@ -5,6 +5,7 @@ import { Formulario } from "src/app/shared/data/models/formulario.model";
 import {
   formularioDependencias,
   formularioInformacionAuditoria,
+  formularioTemasAuditoria,
 } from "./editar-seguimiento.utilidades";
 import { BreakpointObserver } from "@angular/cdk/layout";
 import { AlertService } from "src/app/shared/services/alert.service";
@@ -38,6 +39,10 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
   @ViewChild("formularioInformacionComp")
   formularioInformacionComponent!: FormularioDinamicoComponent;
   formularioInformacion: Formulario | undefined;
+
+  @ViewChild("formularioTemasComp")
+  formularioTemasComponent!: FormularioDinamicoComponent;
+  formularioTemas: Formulario | undefined;
 
   @ViewChildren("formularioDependenciasComp")
   formularioDependenciasComponent!: QueryList<FormularioDinamicoComponent>;
@@ -102,6 +107,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
 
   cargarFormularios(): void {
     this.formularioInformacion = formularioInformacionAuditoria;
+    this.formularioTemas = formularioTemasAuditoria;
   }
 
   enviarFormInformacion() {
@@ -111,6 +117,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
     }
 
     this.formularioInformacionComponent.onSubmit();
+    this.formularioTemasComponent.onSubmit();
   }
 
   preguntarGuardadoInformacion(dataForm: any) {
@@ -118,7 +125,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
       return;
     }
 
-    if (!dataForm) {
+    if (!dataForm || !this.formularioTemasComponent.form.valid) {
       return this.alertaService.showAlert(
         "Formulario incompleto",
         "Debe llenar todos los campos obligatorios"
@@ -176,6 +183,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
       };
       return correo;
     });
+    const tema = this.formularioTemasComponent.form.value.tema;
     return {
       alcance: informacion.alcance_auditoria,
       consecutivo_IE: informacion.consecutivo_IE,
@@ -185,6 +193,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
       fecha_inicio: informacion.fecha_ejecucion_inicial,
       consecutivo_no_auditoria: informacion.consecutivo_no_auditoria,
       objetivo: informacion.objetivo_auditoria,
+      tema: tema,
       correo_complementario: correos,
     };
   }
@@ -259,8 +268,15 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
       consecutivo_IE: this.auditoria.consecutivo_IE,
       macroproceso: this.auditoria.macroproceso_nombre,
       proceso: this.auditoria.proceso_nombre,
+      objetivo_auditoria: this.auditoria.objetivo,
+      alcance_auditoria: this.auditoria.alcance,
+      criterios: this.auditoria.criterio,
       fecha_ejecucion_inicial: this.auditoria.fecha_inicio,
       fecha_ejecucion_final: this.auditoria.fecha_fin,
+    });
+
+    this.formularioTemasComponent.form.patchValue({
+      tema: this.auditoria.tema,
     });
 
     this.formularioDependenciasComponent.forEach((comp, i) => {

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.utilidades.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.utilidades.ts
@@ -109,6 +109,25 @@ export const formularioInformacionAuditoria: Formulario = {
   ],
 };
 
+export const formularioTemasAuditoria: Formulario = {
+  campos: [
+    {
+      nombre: "tema",
+      etiqueta: "Solicitud de Información",
+      tipo: "quill",
+      validaciones: [{ tipo: "requerido", valor: "" }],
+      deshabilitado: false,
+      claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
+      placeholder: "Escriba aquí los temas a tratar en la auditoría",
+      quillConfig: {
+        toolbar: [
+          ["bold", "italic"],
+          [{ list: "ordered" }, { list: "bullet" }]
+        ],
+      },
+    }
+  ]
+}
 
 export const formularioDependencias: Formulario = {
   campos: [


### PR DESCRIPTION
This pull request adds a new "Solicitud de Información" (Request for Information) section to the audit tracking editing form, allowing users to specify topics to be addressed during the audit. It introduces a new dynamic form for these topics, ensures their validation and submission, and integrates the new data throughout the component’s logic and UI.

Answers:

- udistrital/sisifo_documentacion#712

**New "Solicitud de Información" section and form:**

- Added a new UI section with a header and icon for "Solicitud de Información" in `editar-seguimiento.component.html`, and included a new dynamic form for audit topics (`formularioTemas`).
- Defined a new form structure `formularioTemasAuditoria` in `editar-seguimiento.utilidades.ts` for capturing audit topics, using a rich text editor with validation.

**Component logic updates:**

- Integrated the new `formularioTemasAuditoria` into the component, managing its state and lifecycle with `@ViewChild` and initializing it alongside other forms. [[1]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R8) [[2]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R43-R46) [[3]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R110)
- Updated the submission logic to validate and submit the new topics form together with the existing information form, and to ensure both are complete before proceeding.
- Modified data handling to include the new "tema" (topic) field when preparing form data for saving or populating the form with existing audit data. [[1]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R186) [[2]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R196) [[3]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R271-R281)