### PR TITLE
fix: Actualizar auditoría interna después de guardar información 

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
@@ -190,6 +190,7 @@ export class EditarAuditoriaComponent implements OnInit, AfterViewInit {
             );
           });
         }
+        this.auditoria = (res as any).Data;
         this.paso1Guardado = true;
         this.stepper.next();
       });


### PR DESCRIPTION
This pull request makes a small change to the `EditarAuditoriaComponent` to ensure that the `auditoria` property is set from the response data after a successful operation. This helps keep the component's state in sync with the backend and load limit dates for activity modifying with up to date values for udistrital/sisifo_documentacion#716.

* Set the `auditoria` property to the value of `Data` from the response object `(res as any).Data` after a successful operation in `editar-auditoria.component.ts`.