### PR TITLE
feat: Implementar texto enriquecido paso 1 formulario fase 2 auditoria interna

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.utilidades.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.utilidades.ts
@@ -81,31 +81,49 @@ export const formularioInformacionAuditoria: Formulario = {
       nombre: "objetivo_auditoria",
       etiqueta: "Objetivo de la Auditoría",
       icono: "flag",
-      tipo: "textarea",
+      tipo: "quill",
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 120 },
+      placeholder: "Escriba aquí el objetivo de la auditoría",
+      quillConfig: {
+        toolbar: [
+          ["bold", "italic"],
+          [{ list: "ordered" }, { list: "bullet" }]
+        ],
+      }
     },
     {
       nombre: "alcance_auditoria",
       etiqueta: "Alcance de la Auditoría",
       icono: "visibility",
-      tipo: "textarea",
+      tipo: "quill",
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 120 },
+      placeholder: "Escriba aquí el alcance de la auditoría",
+      quillConfig: {
+        toolbar: [
+          ["bold", "italic"],
+          [{ list: "ordered" }, { list: "bullet" }]
+        ],
+      }
     },
     {
       nombre: "criterios",
       etiqueta: "Criterios",
       icono: "check_circle",
-      tipo: "textarea",
+      tipo: "quill",
       validaciones: [{ tipo: "requerido", valor: "" }],
       deshabilitado: false,
       claseGrid: "col-lg-12 col-md-12 col-sm-12 col-xs-12",
-      parametros: { altura: 120 },
+      placeholder: "Escriba aquí los criterios de la auditoría",
+      quillConfig: {
+        toolbar: [
+          ["bold", "italic"],
+          [{ list: "ordered" }, { list: "bullet" }]
+        ],
+      }
     },
   ],
 };

--- a/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.css
+++ b/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.css
@@ -3,8 +3,27 @@
 }
 
 ::ng-deep .ql-editor-auto-expand .ql-editor {
+  font-size: 16px;
   min-height: 150px;
   max-height: 500px;
   height: auto !important;
   overflow-y: auto;
 }
+
+.titulo-quill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin-bottom: 8px;
+  color: #731514;
+  margin-top: 12px;
+  margin-bottom: 12px;
+
+  mat-icon {
+    font-size: 1.2rem;
+    width: auto;
+    height: auto;
+  }
+ }

--- a/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.html
+++ b/src/app/shared/elements/components/formulario-dinamico/formulario-dinamico.component.html
@@ -143,6 +143,12 @@
 
         <!-- Campo tipo editor de texto enriquecido -->
         <div *ngSwitchCase="'quill'" class="ql-editor-auto-expand">
+          <label class="titulo-quill">
+            <b>
+              <mat-icon>edit_note</mat-icon>
+              {{ campo.etiqueta }}
+            </b>
+          </label>
           <quill-editor 
             [formControlName]="campo.nombre"
             [modules]="campo.quillConfig!"


### PR DESCRIPTION
- Se implementan los campos de texto enriquecido para los apartados de objetivos, alcance y demás campos de la auditoria.
- Se agregan titulos a los campos de texto enriquecido para determinar cual campo pertenece a cada elemento.