### PR TITLE
feat: Modal para sobrescribir carta de representación

### DIFF
--- a/src/app/core/services/referencia-pdf.service.ts
+++ b/src/app/core/services/referencia-pdf.service.ts
@@ -5,9 +5,13 @@ import { catchError, map, switchMap } from "rxjs/operators";
 import { PlanAnualAuditoriaService } from "./plan-anual-auditoria.service";
 
 export interface DocumentoReferenciaPdf {
+  _id?: string;
+  referencia_id?: string;
+  referencia_tipo?: string;
   nuxeo_id: number;
   nuxeo_enlace: string;
   tipo_id: number;
+  nombre?: string;
   metadatos?: Record<string, any>;
 }
 
@@ -33,7 +37,8 @@ export class ReferenciaPdfService {
     referencia_id: string,
     tipo_id: number,
     metadatos?: Record<string, any>,
-    nuevo: boolean = false
+    nuevo: boolean = false,
+    documentoIdActualizar?: string
   ): Observable<any> {
     const payload = {
       referencia_tipo: referencia_tipo,
@@ -45,6 +50,13 @@ export class ReferenciaPdfService {
       activo: true,
       fecha_creacion: new Date().toISOString(),
     };
+
+    if (documentoIdActualizar) {
+      return this.planAnualAuditoriaService.put(
+        `documento/${documentoIdActualizar}`,
+        payload
+      );
+    }
 
     const queryBase = `referencia_id:${referencia_id},tipo_id:${tipo_id}`;
     const dependenciaId = metadatos?.["dependencia_id"];
@@ -107,7 +119,7 @@ export class ReferenciaPdfService {
     referenciaId: string,
     opciones: ConsultaDocumentosReferenciaOptions = {}
   ): Observable<DocumentoReferenciaPdf[]> {
-    const fields = opciones.fields ?? "nuxeo_id,nuxeo_enlace,tipo_id,metadatos";
+    const fields = opciones.fields ?? "_id,referencia_id,referencia_tipo,nuxeo_id,nuxeo_enlace,tipo_id,nombre,metadatos";
     const limit = opciones.limit ?? 0;
     const tipo = opciones.tipo_id !== undefined ? `tipo_id:${opciones.tipo_id},` : "";
 

--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
@@ -445,13 +445,15 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
     }
 
     const modalInstance = dialogRef.componentInstance;
+    const metadatos = { firmado: false };
     modalInstance.botonGuardar = { icono: "save", texto: "Guardar carta actual" };
     modalInstance.botonGuardarTodos = { icono: "save", texto: "Guardar todas" };
     modalInstance.onGuardarIndividual = (indice: number) => {
       this.guardarDocumento(
         documentos[indice].base64,
         this.construirInfoCarta(infoDocumento, documentos[indice]),
-        () => modalInstance.marcarGuardado(indice)
+        () => modalInstance.marcarGuardado(indice),
+        metadatos
       );
     };
     modalInstance.onGuardarTodos = () => {
@@ -459,7 +461,8 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
         this.guardarDocumento(
           documentoCarta.base64,
           this.construirInfoCarta(infoDocumento, documentoCarta),
-          () => modalInstance.marcarGuardado(indice)
+          () => modalInstance.marcarGuardado(indice),
+          metadatos
         );
       });
     };
@@ -500,7 +503,8 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
   guardarDocumento(
     documentoBase64: any,
     infoDocumento: any,
-    onSuccess?: () => void
+    onSuccess?: () => void,
+    metadatos?: Record<string, any>,
   ) {
     if (this.soloLectura) {
       return;
@@ -514,7 +518,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
           "Documento pdf (" +
           infoDocumento.plantilla +
           ") de auditoría de plan de auditoría",
-        metadatos: {},
+        metadatos: metadatos,
         file: documentoBase64,
       };
 

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.html
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.html
@@ -46,6 +46,16 @@
         <ng-container *ngIf="mostrarAcciones(role, estadoAuditoriaId)">
           <div class="row">
             <div class="col-12 my-4">
+              <button
+                *ngIf="puedeCargarCartaFirmada()"
+                mat-flat-button
+                color="accent"
+                class="mx-2 width-100-md mt-md"
+                (click)="abrirModalCargueCartasFirmadas()"
+              >
+                <mat-icon>upload_file</mat-icon>
+                Cargar Carta Firmada
+              </button>
               <button mat-stroked-button color="primary" class="mx-2 width-100-md"
                 style="border: 1px solid var(--md-primary-500)" (click)="abrirModalRechazo()">
                 <mat-icon>disabled_by_default</mat-icon>Rechazar Auditoría

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -14,15 +14,19 @@ import { AlertService } from "src/app/shared/services/alert.service";
 import { NuxeoService } from "src/app/core/services/nuxeo.service";
 import { DescargaService } from "src/app/shared/services/descarga.service";
 import { ReferenciaPdfService, DocumentoReferenciaPdf } from "src/app/core/services/referencia-pdf.service";
+import { BotonTabDocumentoContext, ModalVerDocumentosComponent, TabDocumento } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
 import { TercerosService } from "src/app/shared/services/terceros.service";
 import { NotificacionesService, DestinatariosEmail, VariablesSolicitud } from "src/app/shared/services/notificaciones.service";
 import { NotificacionRegistroCrudService } from "src/app/core/services/notificacion-registro-crud.service";
 import { PLANTILLA_SOLICITUD_NOMBRE } from "src/app/core/services/notificaciones-mid.service";
 import { ParametrosUtilsService } from "src/app/shared/services/parametros.service";
-import { forkJoin, of, throwError } from "rxjs";
+import { forkJoin, lastValueFrom, of, throwError } from "rxjs";
 import { catchError, exhaustMap, switchMap, tap } from "rxjs/operators";
 
 interface DocumentoAdjuntoRevision {
+  _id?: string;
+  referencia_id?: string;
+  referencia_tipo?: string;
   tipo_id: number;
   nuxeo_enlace: string;
   nombre?: string;
@@ -230,6 +234,90 @@ export class RevisionDocumentosComponent implements OnInit {
       [environment.ROL.ASISTENTE_DEPENDENCIA]: [environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO],
     };
     return condicionesVisibilidad[role]?.includes(estadoAuditoriaId) || false;
+  }
+
+  puedeCargarCartaFirmada(): boolean {
+    const esAuditado =
+      this.role === environment.ROL.JEFE_DEPENDENCIA ||
+      this.role === environment.ROL.ASISTENTE_DEPENDENCIA;
+
+    return (
+      esAuditado &&
+      this.estadoAuditoriaId ===
+        environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO
+    );
+  }
+
+  async abrirModalCargueCartasFirmadas(): Promise<void> {
+    try {
+      const cartas = (await lastValueFrom(
+        this.referenciaPdfService.consultarDocumentos(this.auditoriaId, {})
+      )) as DocumentoAdjuntoRevision[];
+
+      const cartasAuditado = cartas.filter(
+        (documento) =>
+          documento.tipo_id === environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION
+      );
+
+      console.debug("Cartas de representación visibles para modal:", cartasAuditado);
+
+      if (!Array.isArray(cartasAuditado) || cartasAuditado.length === 0) {
+        this.alertService.showAlert(
+          "Sin cartas disponibles",
+          "No se encontraron cartas de representación para cargar firma."
+        );
+        return;
+      }
+
+      const tabs: TabDocumento[] = cartasAuditado.map((documento, index): TabDocumento => {
+        const dependenciaNombre = this.resolverNombreDependencia(documento, index);
+
+        return {
+          nombre: `Carta de representación ${dependenciaNombre}`,
+          tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
+          documentoId: documento._id,
+          botones: [{
+            nombre: "Descargar Carta",
+            accion: async () => {
+              const base64 = await this.nuxeoService.obtenerPorUUID(documento.nuxeo_enlace);
+              this.descargaService.descargarArchivo(
+                base64, "application/pdf", `Carta_Representacion_${dependenciaNombre}`
+              );
+            }
+          }],
+          cargueAdjuntoConfig: {
+            nombreBoton: "Cargar Carta Firmada",
+            iconoBoton: "upload_file",
+            colorBoton: "accent",
+            idTipoDocumento: environment.TIPO_DOCUMENTO.PROGRAMA_TRABAJO_AUDITORIA,
+            descripcion: `Carta de representación firmada - ${dependenciaNombre}`,
+            referenciaTipoFallback: "Auditoria",
+            metadatosAdicionales: { firmado: true },
+            onSuccess: async () => {
+              this.cargarDocumentos();
+            },
+          },
+        };
+      });
+
+      this.dialog.open(ModalVerDocumentosComponent, {
+        width: "1200px",
+        data: {
+          entityId: this.auditoriaId,
+          titulo: "Cartas de representación",
+          descripcion:
+            "Revise y cargue la carta de representación firmada para cada dependencia.",
+          tabs,
+          tipo: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
+          textoBotonCerrar: "Cerrar",
+        },
+      });
+    } catch (error) {
+      console.error("Error al abrir modal de cargue de cartas firmadas", error);
+      this.alertService.showErrorAlert(
+        "No fue posible abrir el modal de cargue de cartas firmadas."
+      );
+    }
   }
 
   cargarDocumentos() {

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.utilidades.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.utilidades.ts
@@ -2,9 +2,9 @@ import { environment } from "src/environments/environment";
 
 const configAuditado = {
   estadoAprobacion: environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_AUDITADO,
-  preguntaAprobacion: "¿Está seguro(a) de firmar y enviar auditoría?",
+  preguntaAprobacion: "¿Está seguro(a) de enviar auditoría?",
   mensajeAprobacion: "La auditoria fue enviada al auditor",
-  botonAprobacion: "Firmar y enviar a Auditor",
+  botonAprobacion: "Enviar a Auditor",
 };
 
 const configJefe = {

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -140,7 +140,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
 
     switch (this.tipoConsulta) {
       case 'auditado':
-        query += `,estado_id:${environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO}`;
+        query += `,estado_id__gte:${environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO}`;
         endpoint = `auditoria/auditado/${this.personaId}/${this.cargoId}?query=${query}&limit=${limit}&offset=${offset}`;
         break;
       case 'jefe_OCI':

--- a/src/app/shared/elements/components/cargar-archivo/cargar-archivo.component.ts
+++ b/src/app/shared/elements/components/cargar-archivo/cargar-archivo.component.ts
@@ -40,6 +40,7 @@ export class CargarArchivoComponent {
       referencia: string;
       metadatos?: Record<string, any>;
       nuevo?: boolean;
+      documentoIdActualizar?: string;
     }
   ) {}
 
@@ -319,7 +320,8 @@ export class CargarArchivoComponent {
           referencia_id,
           tipo_id,
           metadatos,
-          nuevo
+          nuevo,
+          this.data.documentoIdActualizar
         )
         .subscribe({
           next: (response) => {

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.html
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.html
@@ -15,11 +15,21 @@
                 class="modal-btn"
                 *ngFor="let boton of tabs[selectedTab].botones"
                 mat-flat-button [color]="boton.color || 'accent'"
-                (click)="boton.accion()"
+                (click)="ejecutarBotonTab(boton)"
             >
                 {{ boton.nombre }} <mat-icon *ngIf="boton.icono">{{ boton.icono }}</mat-icon>
             </button>
         </ng-container>
+        <button
+            class="modal-btn"
+            *ngIf="tabs && tabs[selectedTab] && tabs[selectedTab].cargueAdjuntoConfig"
+            mat-flat-button
+            [color]="tabs[selectedTab].cargueAdjuntoConfig?.colorBoton || 'accent'"
+            (click)="abrirCargueAdjuntoTabActual()"
+        >
+            {{ tabs[selectedTab].cargueAdjuntoConfig?.nombreBoton || 'Cargar adjunto' }}
+            <mat-icon>{{ tabs[selectedTab].cargueAdjuntoConfig?.iconoBoton || 'upload_file' }}</mat-icon>
+        </button>
     </div>
     <div class="row">
         <div class="col-sm-12 col-md-4 col-lg-3 d-flex flex-column">

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
@@ -1,19 +1,43 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { MAT_DIALOG_DATA, MatDialogRef } from "@angular/material/dialog";
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from "@angular/material/dialog";
 import { lastValueFrom } from "rxjs";
 import { environment } from "src/environments/environment";
 
 //servicios
 import { NuxeoService } from "src/app/core/services/nuxeo.service";
-import { ReferenciaPdfService } from "src/app/core/services/referencia-pdf.service";
+import { DocumentoReferenciaPdf, ReferenciaPdfService } from "src/app/core/services/referencia-pdf.service";
 import { DescargaService } from "src/app/shared/services/descarga.service";
 import { AlertService } from "src/app/shared/services/alert.service";
+import { CargarArchivoComponent } from "src/app/shared/elements/components/cargar-archivo/cargar-archivo.component";
+
+interface DocumentoModal extends DocumentoReferenciaPdf {
+  base64: string;
+}
+
+export interface BotonTabDocumentoContext {
+  tab: TabDocumento;
+  selectedTab: number;
+  documento?: DocumentoReferenciaPdf;
+  refresh: () => Promise<void>;
+}
 
 export interface BotonTabDocumento {
   nombre: string;
-  accion: () => void;
+  accion: (context?: BotonTabDocumentoContext) => void | Promise<void>;
   color?: string;
   icono?: string;
+}
+
+export interface CargueAdjuntoTabConfig {
+  nombreBoton?: string;
+  iconoBoton?: string;
+  colorBoton?: string;
+  tipoArchivo?: "pdf" | "xlsx";
+  idTipoDocumento: number;
+  descripcion: string;
+  referenciaTipoFallback?: string;
+  metadatosAdicionales?: Record<string, any>;
+  onSuccess?: (context: BotonTabDocumentoContext) => void | Promise<void>;
 }
 
 export interface TabDocumento {
@@ -21,6 +45,9 @@ export interface TabDocumento {
   tipoId: number;
   obligatorio?: boolean;
   botones?: BotonTabDocumento[];
+  documentoId?: string;
+  matcherMetadatos?: Record<string, any>;
+  cargueAdjuntoConfig?: CargueAdjuntoTabConfig;
 }
 
 export interface ModalVerDocumentosData {
@@ -41,8 +68,9 @@ export interface ModalVerDocumentosData {
 })
 export class ModalVerDocumentosComponent implements OnInit {
   selectedTab: number = 0;
-  documentos: { base64: string; tipo_id: number }[] = [];
+  documentos: DocumentoModal[] = [];
   documentosPorTab: { [key: number]: string } = {};
+  documentoInfoPorTab: { [key: number]: DocumentoModal } = {};
 
   titulo: string = "Ver documentos";
   descripcion: string = "Documentos";
@@ -54,6 +82,7 @@ export class ModalVerDocumentosComponent implements OnInit {
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: ModalVerDocumentosData,
     public dialogRef: MatDialogRef<ModalVerDocumentosComponent>,
+    private readonly matDialog: MatDialog,
     private readonly alertService: AlertService,
     private readonly referenciaPdfService: ReferenciaPdfService,
     private readonly nuxeoService: NuxeoService,
@@ -72,8 +101,14 @@ export class ModalVerDocumentosComponent implements OnInit {
   }
 
   async ngOnInit() {
+    await this.recargarContenido();
+  }
+
+  async recargarContenido(): Promise<void> {
     try {
       this.documentos = [];
+      this.documentosPorTab = {};
+      this.documentoInfoPorTab = {};
       await this.cargarDocumentos();
       if (this.data.inferTabs)
         this.inferirPestanasDeDocumentos();
@@ -98,7 +133,7 @@ export class ModalVerDocumentosComponent implements OnInit {
 
       enlacesConTipo.forEach((doc, index) => {
         const base64 = base64Files[index];
-        this.documentos.push({ base64, tipo_id: doc.tipo_id });
+        this.documentos.push({ ...doc, base64 });
       });
     } catch (error) {
       console.error("Error al cargar los documentos:", error);
@@ -133,18 +168,27 @@ export class ModalVerDocumentosComponent implements OnInit {
 
   async renderizarDocumentos() {
     try {
-      // ! This method assumes that a document will be well matched to any tab of the same tipo_id, no matter the name.
-      // Map tabs into availability holders
-      const tabHolders = this.tabs.map((tab, i) => ({ idx: i, tab: tab }));
-      this.documentos.forEach((doc) => {
-        // Assign document to the first available tab that matches its tipo_id
-        const holderIdx = tabHolders.findIndex(holder => holder.tab.tipoId === doc.tipo_id);
-        if (holderIdx !== -1) {
-          this.documentosPorTab[tabHolders[holderIdx].idx] = doc.base64;
-          tabHolders.splice(holderIdx, 1);
+      const documentosDisponibles = [...this.documentos];
+
+      this.tabs.forEach((tab, index) => {
+        let documentoIdx = documentosDisponibles.findIndex((doc) =>
+          this.coincideDocumentoConTab(tab, doc)
+        );
+
+        if (documentoIdx === -1) {
+          documentoIdx = documentosDisponibles.findIndex(
+            (doc) => doc.tipo_id === tab.tipoId
+          );
         }
 
-        console.debug(`Documento con tipo_id ${doc.tipo_id} asignado a la pestaña "${this.tabs[holderIdx]?.nombre || 'Sin pestaña coincidente'}"`);
+        if (documentoIdx === -1) {
+          return;
+        }
+
+        const documento = documentosDisponibles[documentoIdx];
+        this.documentosPorTab[index] = documento.base64;
+        this.documentoInfoPorTab[index] = documento;
+        documentosDisponibles.splice(documentoIdx, 1);
       });
     } catch (error) {
       console.error("Error al renderizar los documentos:", error);
@@ -153,6 +197,83 @@ export class ModalVerDocumentosComponent implements OnInit {
       );
       this.dialogRef.close();
     }
+  }
+
+  private coincideDocumentoConTab(tab: TabDocumento, documento: DocumentoModal): boolean {
+    if (tab.documentoId) {
+      return documento._id === tab.documentoId;
+    }
+
+    if (tab.matcherMetadatos) {
+      return Object.entries(tab.matcherMetadatos).every(([key, value]) => {
+        return documento.metadatos?.[key] === value;
+      }) && documento.tipo_id === tab.tipoId;
+    }
+
+    return documento.tipo_id === tab.tipoId;
+  }
+
+  async ejecutarBotonTab(boton: BotonTabDocumento): Promise<void> {
+    await boton.accion(this.getBotonContext());
+  }
+
+  getBotonContext(): BotonTabDocumentoContext {
+    return {
+      tab: this.tabs[this.selectedTab],
+      selectedTab: this.selectedTab,
+      documento: this.documentoInfoPorTab[this.selectedTab],
+      refresh: () => this.recargarContenido(),
+    };
+  }
+
+  abrirCargueAdjuntoTabActual(): void {
+    const tabActual = this.tabs[this.selectedTab];
+    const config = tabActual?.cargueAdjuntoConfig;
+    const documentoActual = this.documentoInfoPorTab[this.selectedTab];
+
+    if (!tabActual || !config) {
+      return;
+    }
+
+    if (!documentoActual?._id) {
+      this.alertService.showErrorAlert("No se encontró el registro del documento a actualizar.");
+      return;
+    }
+
+    const metadatos = {
+      ...(documentoActual.metadatos || {}),
+      ...(config.metadatosAdicionales || {}),
+    };
+
+    const dialogRef = this.matDialog.open(CargarArchivoComponent, {
+      width: "800px",
+      data: {
+        tipoArchivo: config.tipoArchivo || "pdf",
+        id: documentoActual.referencia_id || this.data.entityId,
+        idTipoDocumento: config.idTipoDocumento,
+        descripcion: config.descripcion,
+        cargaLambda: false,
+        tipoIdReferencia: documentoActual.tipo_id,
+        referencia:
+          documentoActual.referencia_tipo ||
+          config.referenciaTipoFallback ||
+          "Auditoria",
+        metadatos,
+        documentoIdActualizar: documentoActual._id,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(async (guardadoExitoso: boolean) => {
+      if (!guardadoExitoso) {
+        return;
+      }
+
+      await this.recargarContenido();
+
+      if (config.onSuccess) {
+        await config.onSuccess(this.getBotonContext());
+      }
+    });
   }
 
   selectTab(index: number) {


### PR DESCRIPTION
This pull request introduces significant improvements to the handling and management of reference PDF documents, especially for the workflow involving the uploading of signed representation letters ("cartas firmadas") in the audit planning module. The changes enhance the flexibility and metadata tracking of document uploads, improve the UI for document actions, and add support for updating existing documents.

Answers:

- udistrital/sisifo_documentacion#715

**1. Enhanced Document Metadata and Update Support**

- The `DocumentoReferenciaPdf` interface now includes additional fields (`_id`, `referencia_id`, `referencia_tipo`, `nombre`) to better track and identify documents.
- The `ReferenciaPdfService`'s upload method now supports updating an existing document by accepting an optional `documentoIdActualizar` parameter. If provided, it performs an update instead of a new upload. [[1]](diffhunk://#diff-32fd2f66e806d8f505f6282e1f901c2692761608b8249dd39f5ff4a641f93352L36-R41) [[2]](diffhunk://#diff-32fd2f66e806d8f505f6282e1f901c2692761608b8249dd39f5ff4a641f93352R54-R60) [[3]](diffhunk://#diff-2b88e9f37c2ddee6fb570cbfb19f92791f94afbd9796cf0f4e046171a4e57f64R43) [[4]](diffhunk://#diff-2b88e9f37c2ddee6fb570cbfb19f92791f94afbd9796cf0f4e046171a4e57f64L322-R324)
- When querying documents, all new metadata fields are now included in the returned results by default.

**2. Improved Document Upload and Review Workflow**

- A new button and workflow allow auditados (audited users) to upload signed representation letters directly from the audit review screen, with appropriate checks for user role and audit state. [[1]](diffhunk://#diff-7f90ea80ce1c91ba176cd7b41afb46102f37c5fd9de3f0a43e2f4c93505b2fdeR49-R58) [[2]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acR239-R322)
- The modal for viewing documents (`ModalVerDocumentosComponent`) now supports per-tab file uploads, with configurable button text, icons, and metadata (including marking documents as "firmado"). [[1]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL2-R50) [[2]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL44-R73) [[3]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bR85) [[4]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bR104-R111) [[5]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL101-R136) [[6]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL136-R191) [[7]](diffhunk://#diff-55eda78587f0b6f9da89450d917032ea4b7cd0cb37bac6a92c6a77191298131bL18-R32)

**3. UI and Usability Improvements**

- The document upload modal now displays a button for uploading signed letters per tab, improving clarity and user experience.
- The "Enviar a Auditor" workflow and messaging have been clarified by updating button labels and confirmation prompts to remove references to signing, aligning with the new process.

**4. Code and Data Structure Enhancements**

- Document matching logic in the modal has been improved to use new metadata fields, ensuring accurate assignment of documents to their respective tabs.
- The document upload and save functions now consistently pass and utilize the `metadatos` object, allowing for better tracking of document status (e.g., whether a letter is signed). [[1]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9R448-R465) [[2]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9L503-R507) [[3]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9L517-R521)

**5. Query Logic Improvements**

- The audit query for auditados now uses a greater-than-or-equal filter on the audit state, ensuring that audits in later states are also included in the results.