### PR TITLE
feat: ajustes de títulos, rutas de navegación y columna tipo evaluación en listado de seguimientos udistrital/sisifo_documentacion#725

### DIFF
--- a/src/app/modules/planeacion/components/seguimiento/seguimiento.component.html
+++ b/src/app/modules/planeacion/components/seguimiento/seguimiento.component.html
@@ -1,7 +1,7 @@
 <plantilla-tarjeta-contenedora
-  [title]="'Seguimiento e Informes'"
+  [title]="'Planeación de Seguimientos e Informes de Ley'"
   [breadcrumb]="
-    '<p>Gestión Auditoría / Planeación / <b>Seguimiento e Informes</b></p>'
+    '<p>Gestión de Auditoría / Planeación / Seguimientos e Informes de Ley</b></p>'
   "
   [contenido]="contenidoDePlantilla"
 ></plantilla-tarjeta-contenedora>

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.css
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.css
@@ -6,6 +6,10 @@
   text-align: center;
 }
 
+.mat-column-tipo_evaluacion {
+  text-align: center;
+}
+
 .mat-column-documentos {
   text-align: center;
 }

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.html
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.html
@@ -1,9 +1,9 @@
 <ng-container *ngIf="banderaTablaSeguimiento">
   <div class="row mt-4">
     <div class="col-12">
-      <h3 class="my-3">Listado de Auditorías Aprobadas en el Plan Anual de Auditorías (PAA)</h3>
+      <h3 class="my-3">Listado de Seguimientos e Informes de Ley Aprobados en el Plan Anual de Auditorías (PAA)</h3>
       <p class="mb-2 mx-2">
-        Seleccione la auditoría de seguimiento o informe para su edición y/o planeación.
+        Seleccione el seguimiento y/o informe de ley para realizar la revisión y/o planeación.
       </p>
     </div>
     <div class="col-12">
@@ -33,6 +33,11 @@
               >
                 <div *ngSwitchCase="'numero'">
                   <span>{{ pageIndex * pageSize + i + 1 }}</span>
+                </div>
+
+                <!-- Tipo Evaluación -->
+                <div *ngSwitchCase="'tipo_evaluacion'">
+                  <span>{{ row.tipo_evaluacion_nombre }}</span>
                 </div>
 
                 <!-- Documentos -->

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.utilidades.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.utilidades.ts
@@ -20,6 +20,12 @@ export const colocacionesContructorTabla = [
     sortable: false,
   },
   {
+    columnDef: "tipo_evaluacion",
+    header: "Tipo Evaluación",
+    cell: (auditoria: any) => auditoria.tipo_evaluacion_nombre,
+    sortable: false,
+  },
+  {
     columnDef: "auditores",
     header: "Auditor(es)",
     cell: (auditoria: any) =>


### PR DESCRIPTION
## Ajustes títulos, descripción y columna Tipo Evaluación · Seguimientos e Informes de Ley (MF PAA)

### Cambios realizados

**`tabla-seguimiento.utilidades.ts`**
- Se agregó columna `tipo_evaluacion` entre `auditoria` y `auditores`

**`tabla-seguimiento.component.html`**
- Se actualizó título del listado a `Listado de Seguimientos e Informes de Ley Aprobados en el Plan Anual de Auditorías (PAA)`
- Se actualizó subtítulo a `Seleccione el seguimiento y/o informe de ley para realizar la revisión y/o planeación`
- Se agregó `*ngSwitchCase` para renderizar la columna `tipo_evaluacion`

**`tabla-seguimiento.component.css`**
- Se agregó estilo `.mat-column-tipo_evaluacion`

**`seguimiento.component.html`**
- Se actualizó `[title]` a `Planeación de Seguimientos e Informes de Ley`
- Se actualizó `[breadcrumb]` a `Gestión de Auditoría / Planeación / Seguimientos e Informes de Ley`
