### PR TITLE
feat: notificacion aceptacion auditor documento

### DIFF
--- a/src/app/core/services/notificaciones-mid.service.ts
+++ b/src/app/core/services/notificaciones-mid.service.ts
@@ -8,6 +8,9 @@ export const TEMPLATED_EMAIL_ENDPOINT = 'email/enviar_templated_email';
 export const PLANTILLA_SOLICITUD_NOMBRE = 'SISIFO_PLANTILLA_SOLICITUD';
 /** Name of the template for rejection emails */
 export const PLANTILLA_RECHAZO_NOMBRE = 'SISIFO_PLANTILLA_RECHAZO';
+/** Plantilla para envio de aceptacion por auditado */
+export const PLANTILLA_CARTA_REPRESENTACION_NOMBRE = 'SISIFO_CARTA_REPRESENTACION';
+
 
 /**
  * This service is a wrapper for the NOTIFICACIONES_MID_SERVICE API,

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -16,7 +16,7 @@ import { DescargaService } from "src/app/shared/services/descarga.service";
 import { ReferenciaPdfService, DocumentoReferenciaPdf } from "src/app/core/services/referencia-pdf.service";
 import { BotonTabDocumentoContext, ModalVerDocumentosComponent, TabDocumento } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
 import { TercerosService } from "src/app/shared/services/terceros.service";
-import { NotificacionesService, DestinatariosEmail, VariablesSolicitud } from "src/app/shared/services/notificaciones.service";
+import { NotificacionesService, DestinatariosEmail, VariablesSolicitud, VariablesCartaRepresentacion } from "src/app/shared/services/notificaciones.service";
 import { NotificacionRegistroCrudService } from "src/app/core/services/notificacion-registro-crud.service";
 import { PLANTILLA_SOLICITUD_NOMBRE } from "src/app/core/services/notificaciones-mid.service";
 import { ParametrosUtilsService } from "src/app/shared/services/parametros.service";
@@ -554,7 +554,7 @@ export class RevisionDocumentosComponent implements OnInit {
  * aprueba y envía el programa de auditoría a revisión del auditado.
  * Los auditores asignados reciben copia (Cc).
  *
- * Los correos se resuelven desde `dependencias_info`, que soporta múltiples dependencias
+ * Los correos se resuelven desde `datos_dependencias`, que soporta múltiples dependencias
  * por auditoría. Los campos opcionales (jefe, asistente, complementario) solo se incluyen
  * si el MID los retorna.
  *
@@ -768,27 +768,24 @@ export class RevisionDocumentosComponent implements OnInit {
               JSON.stringify(destinatarios, null, 2)
             );
 
-            const variablesSolicitud: VariablesSolicitud = {
-              titulo_solicitud: "Aceptación de Auditoría",
-              tipo_solicitud: "notificación de aceptación",
-              // reemplazar PLANTILLA_SOLICITUD_NOMBRE por la plantilla definitiva cuando este el mockup
-              nombre_documento: `Programa de Auditoría${datosAuditoria?.titulo ? ` - ${datosAuditoria.titulo}` : ''}`,
-              vigencia: vigenciaNombre,
-              rol_remitente: rolRemitente,
-              nombre_remitente: nombreRemitente || rolRemitente,
-              fecha_envio: new Date().toLocaleDateString(),
+            const variablesCartaRepresentacion: VariablesCartaRepresentacion = {
+              dependencia:        dependenciasInfo[0]?.dependencia_nombre ?? "",
+              tipo_auditoria:     datosAuditoria?.titulo ?? "",
+              vigencia:           vigenciaNombre,
+              nombre_quien_envia: nombreRemitente || rolRemitente,
+              fecha_envio:        new Date().toLocaleDateString(),
             };
 
-            return this.notificacionesService.enviarNotificacionSolicitud(
+            return this.notificacionesService.enviarNotificacionCartaRepresentacion(
               destinatarios,
-              variablesSolicitud
+              variablesCartaRepresentacion
             ).pipe(
               tap((response: any) => {
                 if (response?.Status == 200) {
                   this.registrarNotificacion(
                     auditoriaId,
                     destinatarios,
-                    variablesSolicitud,
+                    variablesCartaRepresentacion as any,
                     "aceptacion_auditado_cargue_documento"
                   );
                 }

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -135,7 +135,11 @@ export class RevisionDocumentosComponent implements OnInit {
           if (Array.isArray(estadoAprobacion)) {
             this.aprobarAuditoriaSecuencial(estadoAprobacion, mensajeAprobacion);
           } else {
-            this.aprobarAuditoria(estadoAprobacion, mensajeAprobacion);
+            this.aprobarAuditoria(estadoAprobacion, mensajeAprobacion).then(() => {
+              // El auditado firma y envía al auditor
+              // Se notifica al auditor con copia a la dependencia auditada
+              this.notificarAceptacionAuditado(this.auditoriaId);
+            });
           }
         }
       });
@@ -574,7 +578,7 @@ export class RevisionDocumentosComponent implements OnInit {
       exhaustMap(({ auditoria, auditores, vigencias, nombreRemitente }: any) => {
         const datosAuditoria = auditoria?.Data;
         const listaAuditores: any[] = auditores?.Data ?? [];
-        const dependenciasInfo: any[] = datosAuditoria?.dependencias_info ?? [];
+        const dependenciasInfo: any[] = datosAuditoria?.datos_dependencias ?? [];
 
         const vigenciaId = datosAuditoria?.vigencia_id;
         const vigenciaObj = vigencias.find((v: any) => v.Id === vigenciaId);
@@ -672,6 +676,135 @@ export class RevisionDocumentosComponent implements OnInit {
 
     ).subscribe({
       error: (err) => console.warn("Error en notificación envío a auditado:", err),
+    });
+  }
+
+  /**
+   * Notifica a los auditores asignados al programa cuando el auditado
+   * (Jefe o Asistente de dependencia) firma y envía la aceptación de la auditoría
+   * con el cargue del documento.
+   * Los auditores reciben el correo en To, la dependencia auditada en Cc.
+   */
+  private notificarAceptacionAuditado(auditoriaId: string): void {
+    const rolRemitente = "Dependencia Auditada";
+
+    this.tercerosService.getAuthenticatedUserTerceroIdentification().pipe(
+
+      exhaustMap((tercero) => {
+        return forkJoin({
+          auditoria: this.planAuditoriaMid.get(`auditoria/${auditoriaId}`),
+          auditores: this.planAuditoriaService.get(
+            `auditor?query=auditoria_id:${auditoriaId},asignado:true,activo:true&limit=0`
+          ),
+          vigencias: this.parametrosUtilsService.getVigencias(),
+          nombreRemitente: of(tercero.NombreCompleto),
+        });
+      }),
+
+      exhaustMap(({ auditoria, auditores, vigencias, nombreRemitente }: any) => {
+        const datosAuditoria = auditoria?.Data;
+        const listaAuditores: any[] = auditores?.Data ?? [];
+        const dependenciasInfo: any[] = datosAuditoria?.datos_dependencias ?? [];
+
+        const vigenciaId = datosAuditoria?.vigencia_id;
+        const vigenciaObj = vigencias.find((v: any) => v.Id === vigenciaId);
+        const vigenciaNombre = vigenciaObj?.Nombre || (vigenciaId ? String(vigenciaId) : "");
+
+        const correosAuditores$ = listaAuditores.length > 0
+          ? forkJoin(
+              listaAuditores.map((a: any) =>
+                this.tercerosService.getTerceroById(a.auditor_id).pipe(
+                  catchError(() => of(null))
+                )
+              )
+            )
+          : of([]);
+
+        return correosAuditores$.pipe(
+          switchMap((terceros: any[]) => {
+            // Auditores van al To
+            const correosAuditores = terceros
+              .filter((t) => t?.UsuarioWSO2)
+              .map((t) => t.UsuarioWSO2);
+
+            // Dependencia auditada va al Cc
+            const correosDependencia: string[] = dependenciasInfo.flatMap((dep) => {
+              const correos: string[] = [];
+              if (dep.correo_dependencia)    correos.push(dep.correo_dependencia);
+              if (dep.jefe_correo)           correos.push(dep.jefe_correo);
+              if (dep.asistente_correo)      correos.push(dep.asistente_correo);
+              if (dep.correo_complementario) correos.push(dep.correo_complementario);
+              return correos;
+            });
+
+            console.log(
+              "[notificarAceptacionAuditado] dependencias_info recibidas:",
+              JSON.stringify(dependenciasInfo, null, 2)
+            );
+            console.log(
+              "[notificarAceptacionAuditado] To auditores resueltos:",
+              correosAuditores
+            );
+            console.log(
+              "[notificarAceptacionAuditado] Cc dependencia resueltos:",
+              correosDependencia
+            );
+
+            const fijos = environment.NOTIFICACION_ACEPTACION_AUDITADO_DESTINATARIOS;
+            const destinatarios: DestinatariosEmail = {
+              ToAddresses: [
+                ...correosAuditores,
+                ...(fijos?.ToAddresses ?? []),
+              ],
+              CcAddresses: [
+                ...correosDependencia,
+                ...(fijos?.CcAddresses ?? []),
+              ],
+              BccAddresses: fijos?.BccAddresses ?? [],
+            };
+
+            console.log(
+              "[notificarAceptacionAuditado] Payload final destinatarios:",
+              JSON.stringify(destinatarios, null, 2)
+            );
+
+            const variablesSolicitud: VariablesSolicitud = {
+              titulo_solicitud: "Aceptación de Auditoría",
+              tipo_solicitud: "notificación de aceptación",
+              // reemplazar PLANTILLA_SOLICITUD_NOMBRE por la plantilla definitiva cuando este el mockup
+              nombre_documento: `Programa de Auditoría${datosAuditoria?.titulo ? ` - ${datosAuditoria.titulo}` : ''}`,
+              vigencia: vigenciaNombre,
+              rol_remitente: rolRemitente,
+              nombre_remitente: nombreRemitente || rolRemitente,
+              fecha_envio: new Date().toLocaleDateString(),
+            };
+
+            return this.notificacionesService.enviarNotificacionSolicitud(
+              destinatarios,
+              variablesSolicitud
+            ).pipe(
+              tap((response: any) => {
+                if (response?.Status == 200) {
+                  this.registrarNotificacion(
+                    auditoriaId,
+                    destinatarios,
+                    variablesSolicitud,
+                    "aceptacion_auditado_cargue_documento"
+                  );
+                }
+              })
+            );
+          })
+        );
+      }),
+
+      catchError((error) => {
+        console.warn("Error al notificar aceptación del auditado:", error);
+        return throwError(() => error);
+      })
+
+    ).subscribe({
+      error: (err) => console.warn("Error en notificación aceptación auditado:", err),
     });
   }
 

--- a/src/app/shared/services/notificaciones.service.ts
+++ b/src/app/shared/services/notificaciones.service.ts
@@ -4,7 +4,8 @@ import {
   NotificacionesMidService,
   TEMPLATED_EMAIL_ENDPOINT,
   PLANTILLA_SOLICITUD_NOMBRE,
-  PLANTILLA_RECHAZO_NOMBRE
+  PLANTILLA_RECHAZO_NOMBRE,
+  PLANTILLA_CARTA_REPRESENTACION_NOMBRE,
 } from '../../core/services/notificaciones-mid.service';
 import { environment } from '../../../environments/environment';
 
@@ -34,7 +35,7 @@ interface CuerpoTemplatedEmail {
       /** Data structure for email recipient addresses */
       Destination: DestinatariosEmail;
       /** Data for replacing placeholders in the email template */
-      ReplacementTemplateData: VariablesSolicitud | VariablesRechazo;
+      ReplacementTemplateData: VariablesSolicitud | VariablesRechazo | VariablesCartaRepresentacion;
       // TODO: Attatchments member for the email
     }
   ]
@@ -86,6 +87,19 @@ export interface VariablesRechazo {
   /** Name of the sender */
   nombre_remitente: string;
   /** Date the rejection was sent */
+  fecha_envio: string;
+}
+
+export interface VariablesCartaRepresentacion {
+  /**Dependencia auditada que firmó */
+  dependencia: string;
+  /**Tipo de auditoría interna */
+  tipo_auditoria: string;
+  /** Año de vigencia */
+  vigencia: string;
+  /** Auditado que envia */
+  nombre_quien_envia: string;
+  /** fecha de envio */
   fecha_envio: string;
 }
 
@@ -141,6 +155,30 @@ export class NotificacionesService {
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_RECHAZO_NOMBRE,
+      Destinations: [
+        {
+          Destination: destinatarios,
+          ReplacementTemplateData: variables
+        }
+      ]
+    };
+
+    return this.notificacionesMidService.post(TEMPLATED_EMAIL_ENDPOINT, cuerpo);
+  }
+
+  /**
+   * Send a notification email for carta de representacion using the NOTIFICACIONES_MID_SERVICE.
+   * @param {DestinatariosEmail} destinatarios List of email recipients (To, CC, BCC).
+   * @param {VariablesCartaRepresentacion} variables Variables to replace in the carta representacion email template.
+   * @returns {Observable<any>} An Observable containing the response from the email service.
+   */
+  public enviarNotificacionCartaRepresentacion(
+    destinatarios: DestinatariosEmail,
+    variables: VariablesCartaRepresentacion
+  ): Observable<any> {
+    const cuerpo: CuerpoTemplatedEmail = {
+      Source: this.remitenteEmail,
+      Template: PLANTILLA_CARTA_REPRESENTACION_NOMBRE,
       Destinations: [
         {
           Destination: destinatarios,

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -90,6 +90,17 @@ export const environment = {
     BccAddresses: []
   },
 
+  NOTIFICACION_ACEPTACION_AUDITADO_DESTINATARIOS: {
+    ToAddresses: [
+      // correos fijos adicionales para pruebas
+      "pruebaspaa26auditor@yopmail.com",
+    ],
+    CcAddresses: [
+      // "copy.to@ejemplo.com"
+    ],
+    BccAddresses: []
+  },
+
   VIGENCIAS : {
     TIPO_PARAMETRO_ID: 121,
   },

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -90,6 +90,17 @@ export const environment = {
     BccAddresses: []
   },
 
+  NOTIFICACION_ACEPTACION_AUDITADO_DESTINATARIOS: {
+    ToAddresses: [
+      // correos fijos adicionales para pruebas
+      "pruebaspaa26auditor@yopmail.com",
+    ],
+    CcAddresses: [
+      // "copy.to@ejemplo.com"
+    ],
+    BccAddresses: []
+  },
+
   VIGENCIAS : {
     TIPO_PARAMETRO_ID: 100,
   },

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -94,6 +94,17 @@ export const environment = {
     BccAddresses: []
   },
 
+  NOTIFICACION_ACEPTACION_AUDITADO_DESTINATARIOS: {
+    ToAddresses: [
+      // correos fijos adicionales para pruebas
+      "pruebaspaa26auditor@yopmail.com",
+    ],
+    CcAddresses: [
+      // "copy.to@ejemplo.com"
+    ],
+    BccAddresses: []
+  },
+
   VIGENCIAS : {
     TIPO_PARAMETRO_ID: 121,
   },


### PR DESCRIPTION
## Notificación de aceptación del auditado al auditor

Se implementa el envío de notificaciones a los auditores cuando el auditado carga el documento firmado (carta de representación).

### Cambios principales
- Nuevo método `notificarAceptacionAuditado()` en `revision-documentos.component.ts` que invierte los destinatarios respecto a `notificarEnvioAuditado()`
- Corrección en `notificarEnvioAuditado()`: lectura del campo `datos_dependencias` (antes `dependencias_info`)
- Registro de plantilla `SISIFO_CARTA_REPRESENTACION` en AWS SES con variables: `dependencia`, `tipo_auditoria`, `vigencia`, `nombre_quien_envia`, `fecha_envio`
- Nueva interfaz `VariablesCartaRepresentacion` y método `enviarNotificacionCartaRepresentacion()` en `notificaciones.service.ts`
- Reemplazo de la plantilla provisional `SISIFO_PLANTILLA_SOLICITUD` por `SISIFO_CARTA_REPRESENTACION` en el flujo de aceptación
- Log registrado en CRUD con `tipo_notificacion: "aceptacion_auditado_cargue_documento"` al recibir Status 200