### PR TITLE
fix: Cambiar campo medio en formularios de actividad de selección a texto

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/actividades-auditoria/actividad-formulario/actividad-formulario.component.html
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/actividades-auditoria/actividad-formulario/actividad-formulario.component.html
@@ -147,14 +147,11 @@
               <mat-form-field class="col-12" appearance="outline">
                 <mat-label>Medio</mat-label>
                 <mat-icon matPrefix color="primary">folder_open</mat-icon>
-                <mat-select
+                <input
+                  matInput
                   placeholder="Medio"
                   formControlName="papelTrabajoMedio"
-                >
-                  <mat-option disabled value="">--Seleccionar--</mat-option>
-                  <mat-option value="Físico">Físico</mat-option>
-                  <mat-option value="Digital">Digital</mat-option>
-                </mat-select>
+                />
               </mat-form-field>
             </div>
 

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/actividades-seguimiento/actividad-formulario/actividad-formulario.component.html
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/actividades-seguimiento/actividad-formulario/actividad-formulario.component.html
@@ -119,14 +119,11 @@
               <mat-form-field class="col-12" appearance="outline">
                 <mat-label>Medio</mat-label>
                 <mat-icon matPrefix color="primary">folder_open</mat-icon>
-                <mat-select
+                <input
+                  matInput
                   placeholder="Medio"
                   formControlName="papelTrabajoMedio"
-                >
-                  <mat-option disabled value="">--Seleccionar--</mat-option>
-                  <mat-option value="Físico">Físico</mat-option>
-                  <mat-option value="Digital">Digital</mat-option>
-                </mat-select>
+                />
               </mat-form-field>
             </div>
 


### PR DESCRIPTION
This pull request updates the way the "Medio" (Medium) field is handled in the activity forms for both internal audits and follow-up activities. Instead of using a dropdown selector with fixed options, the field is now a free-text input, allowing users to enter any value.

**Form field input changes:**

* Changed the `papelTrabajoMedio` field from a `mat-select` dropdown to a free-text `input` field in `actividad-formulario.component.html` for both auditorias internas and seguimiento modules. This allows users to type any medium instead of selecting from predefined options. [[1]](diffhunk://#diff-9ab34a062698991e0fc4d6cb221b8dcdabd1cee62e155f4b87dd03c671577cbbL150-R154) [[2]](diffhunk://#diff-1421be91fc5db5e79e269de54ccd9664f99f93be73f4b890e6b13a29711411a2L122-R126)

## Functional test

<img width="1380" height="626" alt="image" src="https://github.com/user-attachments/assets/42098662-c81f-4221-94e7-0981f6221622" />
<img width="1105" height="831" alt="image" src="https://github.com/user-attachments/assets/6fd03b81-833c-47ba-a0a6-c71caeb1208a" />
<img width="1290" height="610" alt="image" src="https://github.com/user-attachments/assets/8754d302-ced4-4a09-8bb3-efb4e0178763" />
<img width="1292" height="609" alt="image" src="https://github.com/user-attachments/assets/27d31a37-2b59-4ed8-8902-32f0f0008250" />
