### PR TITLE
feat: Remplazar documentos en auditoría interna

### DIFF
--- a/src/app/core/services/referencia-pdf.service.ts
+++ b/src/app/core/services/referencia-pdf.service.ts
@@ -21,6 +21,7 @@ export interface ConsultaDocumentosReferenciaOptions {
   tipo_id?: number;
   fields?: string;
   limit?: number;
+  deduplicarPorTipo?: boolean;
 }
 
 @Injectable({
@@ -122,6 +123,7 @@ export class ReferenciaPdfService {
   ): Observable<DocumentoReferenciaPdf[]> {
     const limit = opciones.limit ?? 0;
     const tipo = opciones.tipo_id !== undefined ? `tipo_id:${opciones.tipo_id},` : "";
+    const deduplicarPorTipo = opciones.deduplicarPorTipo ?? true;
 
     return this.planAnualAuditoriaService
       .get(
@@ -130,9 +132,15 @@ export class ReferenciaPdfService {
       .pipe(
         map((response: any) => {
           if (response && response.Data && Array.isArray(response.Data)) {
-            return tipo ? response.Data.filter(
-                (item: DocumentoReferenciaPdf) => item?.nuxeo_enlace && item?.tipo_id
-              ) : this.filtrarValidos(response.Data);
+            const documentosValidos = response.Data.filter(
+              (item: DocumentoReferenciaPdf) => item?.nuxeo_enlace && item?.tipo_id
+            );
+
+            if (tipo || !deduplicarPorTipo) {
+              return documentosValidos;
+            }
+
+            return this.filtrarValidos(documentosValidos);
           }
           throw new Error("No se encontraron enlaces válidos en la respuesta.");
         }),

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -22,9 +22,9 @@ import { NuxeoService } from "src/app/core/services/nuxeo.service";
 import { ReferenciaPdfService } from "src/app/core/services/referencia-pdf.service";
 import { RolService } from "src/app/core/services/rol.service";
 import { accionesPlaneacion } from "src/app/shared/utils/accionesPorRolYEstado";
-import { forkJoin, of, throwError } from "rxjs";
-import { catchError, exhaustMap, tap } from "rxjs/operators";
-import { ModalVerDocumentosComponent } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
+import { forkJoin, lastValueFrom, of, throwError } from "rxjs";
+import { catchError, exhaustMap, map, tap } from "rxjs/operators";
+import { ModalVerDocumentosComponent, TabDocumento } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
 import { TercerosService } from "src/app/shared/services/terceros.service";
 import {
   NotificacionesService,
@@ -34,6 +34,8 @@ import {
 import { NotificacionRegistroCrudService } from "src/app/core/services/notificacion-registro-crud.service";
 import { PLANTILLA_SOLICITUD_NOMBRE } from "src/app/core/services/notificaciones-mid.service";
 import { ParametrosUtilsService } from "src/app/shared/services/parametros.service";
+import { CargueAdjuntoTabConfig } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
+import { OikosService } from "src/app/core/services/oikos.service";
 
 interface DocumentoAdjuntoCarta {
   nuxeo_enlace?: string;
@@ -95,6 +97,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
     private readonly notificacionesService: NotificacionesService,
     private readonly notificacionRegistroCrudService: NotificacionRegistroCrudService,
     private readonly parametrosUtilsService: ParametrosUtilsService,
+    private readonly oikosService: OikosService,
   ) {}
 
   ngOnInit() {
@@ -270,18 +273,88 @@ export class TablaAuditoriasInternasComponent implements OnInit {
       });
   }
 
-  verDocumentos(auditoria: Auditoria) {
+  async verDocumentos(auditoria: Auditoria) {
     const auditoriaId = auditoria._id;
+    const getAdjuntoConfigByRole = (rol: string): CargueAdjuntoTabConfig | undefined => {
+      if (rol === environment.ROL.JEFE_DEPENDENCIA || rol === environment.ROL.ASISTENTE_DEPENDENCIA)
+        return undefined;
+
+      return {
+        nombreBoton: "Remplazar documento",
+        iconoBoton: "upload_file",
+        colorBoton: "primary",
+        tipoArchivo: "pdf",
+        idTipoDocumento: environment.TIPO_DOCUMENTO.PROGRAMA_TRABAJO_AUDITORIA,
+        descripcion: "Remplazar el documento asociado a esta auditoría",
+        onSuccess: () => this.listarAuditoriasPorVigencia(this.vigenciaId, this.pageSize, this.pageIndex * this.pageSize),
+      }
+    };
+
+    const cartas: any[] = await lastValueFrom(
+      this.referenciaPdfService
+        .consultarDocumentos(auditoriaId, { tipo_id: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION })
+        .pipe(
+          catchError((error) => {
+            console.error("Error consultando cantidad de cartas de presentación:", error);
+            return of([]);
+          })
+        )
+    );
+
+    const dependenciasCartas = await lastValueFrom(
+      this.oikosService
+        .get(
+          `dependencia?fields=Id,Nombre&limit=0`)
+        .pipe(
+          map((response: any) => {
+            const mapa = new Map<number, string>();
+            response.map( (dep: any) => mapa.set(dep.Id, dep.Nombre) );
+            return mapa;
+          }),
+          catchError((error) => {
+            console.error("Error consultando dependencias para cartas de presentación:", error);
+            return of(new Map<number, string>());
+          })
+        )
+      );
+
+    const tabsCartasPresentacion: TabDocumento[] = cartas.map((carta) => {
+      const cargueAdjuntoConfig = getAdjuntoConfigByRole(this.role);
+      return {
+        nombre: "Carta de representación - " + (dependenciasCartas.get(carta.metadatos?.dependencia_id) || "Dependencia desconocida"),
+        documentoId: carta._id,
+        tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
+        cargueAdjuntoConfig: cargueAdjuntoConfig
+          ? {
+              ...cargueAdjuntoConfig,
+              metadatosAdicionales: { firmada: true},
+            }
+          : undefined,
+      }
+    });
+
     this.dialog.open(ModalVerDocumentosComponent, {
       width: "1200px",
       data: {
         entityId: auditoriaId,
         inferTabs: false,
         tabs: [
-          { nombre: "Programa de auditoría", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.PROGRAMA_TRABAJO },
-          { nombre: "Solicitud de información", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.SOLICITUD_INFORMACION },
-          { nombre: "Carta de representación", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION },
-          { nombre: "Compromiso ético", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.COMPROMISO_ETICO },
+          {
+            nombre: "Programa de auditoría",
+            tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.PROGRAMA_TRABAJO,
+            cargueAdjuntoConfig: getAdjuntoConfigByRole(this.role),
+          },
+          {
+            nombre: "Solicitud de información",
+            tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.SOLICITUD_INFORMACION,
+            cargueAdjuntoConfig: getAdjuntoConfigByRole(this.role),
+          },
+          ...tabsCartasPresentacion,
+          {
+            nombre: "Compromiso ético",
+            tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.COMPROMISO_ETICO,
+            cargueAdjuntoConfig: getAdjuntoConfigByRole(this.role),
+          },
         ],
         titulo: `${tituloYSubtituloAuditoria(auditoria)}`,
         descripcion: `Documentos asociados a la auditoría`

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -273,35 +273,51 @@ export class TablaAuditoriasInternasComponent implements OnInit {
       });
   }
 
-  async verDocumentos(auditoria: Auditoria) {
-    const auditoriaId = auditoria._id;
-    const getAdjuntoConfigByRole = (rol: string): CargueAdjuntoTabConfig | undefined => {
-      if (rol === environment.ROL.JEFE_DEPENDENCIA || rol === environment.ROL.ASISTENTE_DEPENDENCIA)
-        return undefined;
+  puedeRemplazarDocumento(rol: string): boolean {
+    return [
+        environment.ROL.AUDITOR_EXPERTO,
+        environment.ROL.AUDITOR,
+        environment.ROL.AUDITOR_ASISTENTE
+      ].includes(rol);
+  }
 
-      return {
-        nombreBoton: "Remplazar documento",
-        iconoBoton: "upload_file",
-        colorBoton: "primary",
-        tipoArchivo: "pdf",
-        idTipoDocumento: environment.TIPO_DOCUMENTO.PROGRAMA_TRABAJO_AUDITORIA,
-        descripcion: "Remplazar el documento asociado a esta auditoría",
-        onSuccess: () => this.listarAuditoriasPorVigencia(this.vigenciaId, this.pageSize, this.pageIndex * this.pageSize),
-      }
-    };
+  private esUsuarioAuditado(): boolean {
+    return this.tipoConsulta === "auditado";
+  }
 
-    const cartas: any[] = await lastValueFrom(
-      this.referenciaPdfService
-        .consultarDocumentos(auditoriaId, { tipo_id: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION })
+  private async obtenerCartasVisibles(auditoriaId: string): Promise<any[]> {
+    if (!this.esUsuarioAuditado()) {
+      return await lastValueFrom(
+        this.referenciaPdfService
+          .consultarDocumentos(auditoriaId, { tipo_id: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION })
+          .pipe(
+            catchError((error) => {
+              console.error("Error consultando cantidad de cartas de presentación:", error);
+              return of([]);
+            })
+          )
+      );
+    }
+
+    const personaIdAuditado = this.personaId || await this.userService.getPersonaId();
+    const documentosVisiblesAuditado: any[] = await lastValueFrom(
+      this.planAuditoriaMid
+        .get(`auditado/${personaIdAuditado}/documento?auditoria_id=${auditoriaId}&cargo_id=${this.cargoId}`)
         .pipe(
           catchError((error) => {
-            console.error("Error consultando cantidad de cartas de presentación:", error);
+            console.error("Error consultando documentos visibles para auditado:", error);
             return of([]);
           })
         )
     );
 
-    const dependenciasCartas = await lastValueFrom(
+    return documentosVisiblesAuditado.filter(
+      (documento: any) => documento.tipo_id === environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION
+    );
+  }
+
+  private async obtenerMapaDependencias(): Promise<Map<number, string>> {
+    return await lastValueFrom(
       this.oikosService
         .get(
           `dependencia?fields=Id,Nombre&limit=0`)
@@ -317,21 +333,45 @@ export class TablaAuditoriasInternasComponent implements OnInit {
           })
         )
       );
+  }
 
-    const tabsCartasPresentacion: TabDocumento[] = cartas.map((carta) => {
-      const cargueAdjuntoConfig = getAdjuntoConfigByRole(this.role);
+  async verDocumentos(auditoria: Auditoria) {
+    const auditoriaId = auditoria._id;
+    const getAdjuntoConfigByRole = (rol: string): CargueAdjuntoTabConfig | undefined => {
+      if (!this.puedeRemplazarDocumento(rol))
+        return undefined;
+
       return {
-        nombre: "Carta de representación - " + (dependenciasCartas.get(carta.metadatos?.dependencia_id) || "Dependencia desconocida"),
-        documentoId: carta._id,
-        tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
-        cargueAdjuntoConfig: cargueAdjuntoConfig
-          ? {
-              ...cargueAdjuntoConfig,
-              metadatosAdicionales: { firmada: true},
-            }
-          : undefined,
+        nombreBoton: "Remplazar documento",
+        iconoBoton: "upload_file",
+        colorBoton: "primary",
+        tipoArchivo: "pdf",
+        idTipoDocumento: environment.TIPO_DOCUMENTO.PROGRAMA_TRABAJO_AUDITORIA,
+        descripcion: "Remplazar el documento asociado a esta auditoría",
+        onSuccess: () => this.listarAuditoriasPorVigencia(this.vigenciaId, this.pageSize, this.pageIndex * this.pageSize),
       }
-    });
+    };
+
+    const [cartas, dependenciasCartas] = await Promise.all([
+      this.obtenerCartasVisibles(auditoriaId),
+      this.obtenerMapaDependencias(),
+    ]);
+
+    const tabsCartasPresentacion: TabDocumento[] = cartas
+      .map((carta) => {
+        const cargueAdjuntoConfig = getAdjuntoConfigByRole(this.role);
+        return {
+          nombre: "Carta de representación - " + (dependenciasCartas.get(carta.metadatos?.dependencia_id) || "Dependencia desconocida"),
+          documentoId: carta._id,
+          tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
+          cargueAdjuntoConfig: cargueAdjuntoConfig
+            ? {
+                ...cargueAdjuntoConfig,
+                metadatosAdicionales: { firmada: true},
+              }
+            : undefined,
+        }
+      });
 
     this.dialog.open(ModalVerDocumentosComponent, {
       width: "1200px",

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
@@ -124,7 +124,10 @@ export class ModalVerDocumentosComponent implements OnInit {
    */
   async cargarDocumentos() {
     try {
-      const opciones = this.consultarPorTipo ? { tipo_id: this.data.tipo } : {};
+      const tieneTabsConDocumentoId = this.tabs.some((tab) => !!tab.documentoId);
+      const opciones = this.consultarPorTipo
+        ? { tipo_id: this.data.tipo }
+        : { deduplicarPorTipo: !tieneTabsConDocumentoId };
       const enlacesConTipo = await lastValueFrom(
         this.referenciaPdfService.consultarDocumentos(this.data.entityId, opciones)
       );
@@ -193,6 +196,9 @@ export class ModalVerDocumentosComponent implements OnInit {
         const documento = documentosDisponibles[documentoIdx];
         this.documentosPorTab[index] = documento.base64;
         this.documentoInfoPorTab[index] = documento;
+        if (!this.tabs[index].documentoId) {
+          this.tabs[index].documentoId = documento._id;
+        }
         documentosDisponibles.splice(documentoIdx, 1);
       });
     } catch (error) {


### PR DESCRIPTION
This pull request introduces several improvements to the handling and display of referenced PDF documents in the audit module, focusing on more flexible document tab configuration and improved deduplication logic. The main changes include enhanced configuration of document upload options per user role, dynamic generation of document tabs (especially for presentation letters), and smarter deduplication when fetching documents.

Answers:

- udistrital/sisifo_documentacion#737

**Document tab configuration and dynamic tab generation:**

* Added logic to dynamically generate tabs for each "Carta de representación" document, including fetching dependency names and customizing tab display names. Tabs now support custom upload configurations based on user roles, allowing or restricting document replacement as appropriate. (`src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas.component.ts` [src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.tsL273-R357](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L273-R357))
* Integrated the `OikosService` to retrieve dependency information for more descriptive tab naming. (`src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas.component.ts` [[1]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5R37-R38) [[2]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5R100)

**Document fetching and deduplication logic:**

* Updated the `ReferenciaPdfService` to accept a new `deduplicarPorTipo` option, allowing the caller to control whether documents should be deduplicated by type. The default is now `true`, but can be overridden per call. (`src/app/core/services/referencia-pdf.service.ts` [[1]](diffhunk://#diff-32fd2f66e806d8f505f6282e1f901c2692761608b8249dd39f5ff4a641f93352R24) [[2]](diffhunk://#diff-32fd2f66e806d8f505f6282e1f901c2692761608b8249dd39f5ff4a641f93352R126) [[3]](diffhunk://#diff-32fd2f66e806d8f505f6282e1f901c2692761608b8249dd39f5ff4a641f93352L133-R143)
* Modified the document modal to set the `deduplicarPorTipo` option based on whether any tabs already specify a `documentoId`, preventing unwanted deduplication when specific documents are targeted. (`src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts` [src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.tsL127-R130](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL127-R130))

**Tab/document state management:**

* Ensured that when a document is loaded for a tab without a predefined `documentoId`, the tab's `documentoId` is set to the loaded document's ID, improving consistency and future lookups. (`src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts` [src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.tsR199-R201](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bR199-R201))

**Imports and dependencies:**

* Added necessary imports for new services and types used in the updated logic. (`src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas.component.ts` [src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.tsR37-R38](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5R37-R38))

These changes collectively provide a more flexible and robust system for managing and displaying audit-related documents, with improved user experience and role-based controls.