### PR TITLE
feat: implementar modal de observaciones en envio de PAA y ajuste de filtros en historial udistrital/sisifo_documentacion#730

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
@@ -384,9 +384,9 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
 
   verCompromisoEtico() {
     const dialogRef = this.dialog.open(ModalVisualizarRecargarCompromisoEticoComponent, {
-      data: { base64Document: this.base64CompromisoEtico, id: this.auditoriaId, soloLectura: this.soloLectura },
-      width: "80%",
-      height: "80vh",
+      data: { base64Document: this.base64CompromisoEtico, id: this.auditoriaId },
+      width: "1000px",
+      autoFocus: false,
     });
 
     dialogRef.afterClosed().subscribe((resultado: boolean | 'deleted') => {

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan-auditoria.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan-auditoria.component.ts
@@ -26,6 +26,7 @@ import {
 import { NotificacionRegistroCrudService } from "src/app/core/services/notificacion-registro-crud.service";
 import { DocumentoUtils } from "./consulta-plan.auditoria.utils";
 import { ModalVerDocumentosComponent } from "src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component";
+import { ModalEnviarAprobacionComponent } from "./modal-enviar-aprobacion/modal-enviar-aprobacion.component";
 
 const PLANTILLA_SOLICITUD_NOMBRE = "SISIFO_PLANTILLA_SOLICITUD";
 
@@ -114,10 +115,11 @@ export class ConsultaPlanAuditoriaComponent implements OnInit {
     this.offset = 0;
   }
 
-  construirEstado(planId: string, estadoId: number, observacion = "") {
+  construirEstado(planId: string, estadoId: number, observacion = "", usuarioRol?: string) {
     return {
       plan_auditoria_id: planId,
       usuario_id: this.usuarioId,
+      usuario_rol: usuarioRol ?? null,
       observacion,
       estado_id: estadoId,
     };
@@ -148,7 +150,7 @@ export class ConsultaPlanAuditoriaComponent implements OnInit {
           const estadoId = item.estado?.estado_id;
           const vigenciaId = item.vigencia_id;
           let acciones = this.getAccionesPorRolYEstado(estadoId);
-          if (!item.tiene_rechazos) {
+          if (!item.tiene_rechazos && !item.tiene_observaciones) {
             acciones = acciones.filter(
               (accion) => accion !== "Historial de Observaciones"
             );
@@ -302,84 +304,72 @@ export class ConsultaPlanAuditoriaComponent implements OnInit {
   }
 
   enviarPlan(element: any) {
-    this.alertaService
-      .showConfirmAlert(
-        "¿Está seguro(a) de enviar el Plan Anual de Auditoría (PAA)?"
-      )
-      .then((result) => {
-        if (result.isConfirmed) {
-          this.planAnualAuditoriaService
-            .get(
-              `documento?query=referencia_id:${element.id},tipo_id:6810,activo:true`
-            )
-            .subscribe({
-              next: (documentos) => {
-                if (true)
-                if (documentos && documentos.Data.length > 0) {
-                  const nuevoEstado = this.construirEstado(
-                    element.id,
-                    environment.PLAN_ESTADO.EN_REVISION_JEFE_ID
-                  );
+    const dialogRef = this.dialog.open(ModalEnviarAprobacionComponent, {
+      width: '500px',
+      autoFocus: false,
+    });
 
-                  this.planAnualAuditoriaService
-                    .post("estado", nuevoEstado)
-                    .subscribe({
-                      next: (nuevoEstadoResponse: any) => {
-                        if (nuevoEstadoResponse.Status === 201) {
-                          this.notificarEnvioPlan(element).pipe(
+    dialogRef.afterClosed().subscribe((observacion: string | null) => {
+      // null = canceló con botón, undefined = cerró con X o backdrop
+      if (observacion === null || observacion === undefined) return;
 
-                            exhaustMap((response: any) => {
-                              if (response.Status == 200) {
-                                this.alertaService.showSuccessAlert(
-                                  "Plan enviado exitosamente"
-                                );
-                                return of(response);
-                              }
+      this.planAnualAuditoriaService
+        .get(`documento?query=referencia_id:${element.id},tipo_id:6810,activo:true`)
+        .subscribe({
+          next: (documentos) => {
+            if (documentos && documentos.Data.length > 0) {
+              const nuevoEstado = this.construirEstado(
+                element.id,
+                environment.PLAN_ESTADO.EN_REVISION_JEFE_ID,
+                observacion,
+                this.roles[0]
+              );
 
-                              console.error("Solicitud de notificación fallida:", response);
-                              return throwError(() => new Error("Solicitud de notificación fallida"));
-                            }),
-
-                            catchError((error) => {
-                              this.alertaService.showAlert(
-                                "Error en notificación",
-                                "El plan fue asociado exitosamente, pero hubo un problema al enviar la notificación."
-                              );
-
-                              return throwError(() => new Error("Error en notificación", error));
-                            }),
-
-                          ).subscribe();
-                          this.iniciarPaginacion();
-                          this.cargarPlanesAuditoria(this.opcionesPagina[0], 0);
-                        } else {
-                          this.alertaService.showErrorAlert(
-                            "Error al asociar el estado al plan"
-                          );
+              this.planAnualAuditoriaService.post('estado', nuevoEstado).subscribe({
+                next: (nuevoEstadoResponse: any) => {
+                  if (nuevoEstadoResponse.Status === 201) {
+                    this.notificarEnvioPlan(element).pipe(
+                      exhaustMap((response: any) => {
+                        if (response.Status == 200) {
+                          this.alertaService.showSuccessAlert('Plan enviado exitosamente');
+                          return of(response);
                         }
-                      },
-                      error: (nuevoEstadoError) => {
-                        this.alertaService.showErrorAlert(
-                          "Error al asociar el estado al plan"
+                        console.error('Solicitud de notificación fallida:', response);
+                        return throwError(() => new Error('Solicitud de notificación fallida'));
+                      }),
+                      catchError((error) => {
+                        this.alertaService.showAlert(
+                          'Error en notificación',
+                          'El plan fue asociado exitosamente, pero hubo un problema al enviar la notificación.'
                         );
-                        console.error(nuevoEstadoError);
-                      }
-                    });
-                } else {
-                  this.alertaService.showErrorAlert(
-                    "No cuenta con el PDF del Plan Anual de Auditoría creado"
-                  );
-                }
-              },
-              error: (error) => {
-                this.alertaService.showErrorAlert(
-                  "Error al verificar la existencia del documento asociado."
-                );
-                console.error(error);
-              }
-            });
-        }
-      });
+                        return throwError(() => new Error('Error en notificación', error));
+                      }),
+                    ).subscribe();
+                    this.iniciarPaginacion();
+                    this.cargarPlanesAuditoria(this.opcionesPagina[0], 0);
+                  } else {
+                    this.alertaService.showErrorAlert('Error al asociar el estado al plan');
+                  }
+                },
+                error: (nuevoEstadoError) => {
+                  this.alertaService.showErrorAlert('Error al asociar el estado al plan');
+                  console.error(nuevoEstadoError);
+                },
+              });
+            } else {
+              this.alertaService.showErrorAlert(
+                'No cuenta con el PDF del Plan Anual de Auditoría creado'
+              );
+            }
+          },
+          error: (error) => {
+            this.alertaService.showErrorAlert(
+              'Error al verificar la existencia del documento asociado.'
+            );
+            console.error(error);
+          },
+        });
+    });
   }
 
   /**

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component.html
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component.html
@@ -1,0 +1,50 @@
+<plantilla-modal
+  [icono]="'send'"
+  [titulo]="'Enviar a Aprobación'"
+  [descripcion]="'Enviar el Plan Anual de Auditoría al Jefe para su aprobación'"
+  [contenido]="contenidoDeModal"
+></plantilla-modal>
+
+<ng-template #contenidoDeModal>
+  <div class="row mt-2">
+    <div class="col-12">
+      <form [formGroup]="form">
+        <mat-form-field appearance="outline" class="col-12">
+          <mat-label>Observación (opcional)</mat-label>
+          <mat-icon color="primary" matPrefix>comment</mat-icon>
+          <textarea
+            style="height: 100px; resize: none"
+            matInput
+            formControlName="observacion"
+            placeholder="Ingrese una observación opcional para el Jefe..."
+          ></textarea>
+        </mat-form-field>
+      </form>
+
+      <div class="d-flex justify-content-center align-items-center fondo-acento-50 my-2">
+        <mat-icon>info</mat-icon>
+        <p class="mx-2">¿Está seguro(a) de enviar el Plan Anual de Auditoría (PAA)?</p>
+      </div>
+
+      <mat-dialog-actions align="center">
+        <button
+          mat-stroked-button
+          color="primary"
+          style="border: 1px solid var(--md-primary-500)"
+          [mat-dialog-close]="null"
+          class="mb-sm"
+        >
+          <mat-icon>close</mat-icon>Cancelar
+        </button>
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="confirmar()"
+          class="mb-sm"
+        >
+          <mat-icon>send</mat-icon>Sí, enviar
+        </button>
+      </mat-dialog-actions>
+    </div>
+  </div>
+</ng-template>

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component.spec.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ModalEnviarAprobacionComponent } from './modal-enviar-aprobacion.component';
+
+describe('ModalEnviarAprobacionComponent', () => {
+  let component: ModalEnviarAprobacionComponent;
+  let fixture: ComponentFixture<ModalEnviarAprobacionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ModalEnviarAprobacionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ModalEnviarAprobacionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-modal-enviar-aprobacion',
+  templateUrl: './modal-enviar-aprobacion.component.html',
+})
+export class ModalEnviarAprobacionComponent {
+  form: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    private dialogRef: MatDialogRef<ModalEnviarAprobacionComponent>
+  ) {
+    this.form = this.fb.group({
+      observacion: [''],
+    });
+
+    this.dialogRef.beforeClosed().subscribe((result) => {
+      if (result === undefined) {
+        this.dialogRef.close(null);
+      }
+    });
+  }
+
+  confirmar(): void {
+    // Retorna string (puede ser vacío), null significa que canceló
+    this.dialogRef.close(this.form.value.observacion ?? '');
+  }
+}

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component.html
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component.html
@@ -66,7 +66,7 @@
                 </div>
                 <div class="chip mb-sm">
                   <mat-icon class="icon-chip">person</mat-icon>
-                  <b>Etapa: {{ revision.usuario_rol || revision.estado?.nombre }}</b>
+                  <b>Rol: {{ revision.usuario_rol || revision.estado?.nombre }}</b>
                 </div>
                 <div class="chip mb-sm">
                   <mat-icon class="icon-chip">calendar_today</mat-icon>

--- a/src/app/modules/programacion/programacion.module.ts
+++ b/src/app/modules/programacion/programacion.module.ts
@@ -21,6 +21,8 @@ import { ModalPdfVisualizadorComponent } from "./components/consulta-plan-audito
 import { RegistrarAuditoriasComponent } from "./components/consulta-plan-auditoria/registrar-auditorias/registrar-auditorias.component";
 import { ModalAgregarAuditorComponent } from "./components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component";
 import { ModalListaRechazosComponent } from "./components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component";
+import { ModalEnviarAprobacionComponent } from "./components/consulta-plan-auditoria/modal-enviar-aprobacion/modal-enviar-aprobacion.component";
+
 
 import { MatTooltip } from "@angular/material/tooltip";
 import { UnirConComaPipe } from "src/app/shared/pipes/unir-con-coma.pipe";
@@ -45,6 +47,7 @@ import { TablaAuditoriasEspecialesComponent } from "./components/auditorias-espe
     TablaConsultaAuditoriasComponent,
     ModalAuditoriasHijasComponent,
     ModalVisualizarRecargarDocumentoComponent,
+    ModalEnviarAprobacionComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
### `consulta-plan-auditoria`
- Nuevo componente `modal-enviar-aprobacion` con textarea opcional y manejo de cierre por X/Cancelar/Confirmar
- `construirEstado()` ahora recibe y envía `usuario_rol`
- `enviarPlan()` abre el nuevo modal en lugar del `showConfirmAlert`
- Filtro de acción "Historial de Observaciones" actualizado: se muestra si `tiene_rechazos` **o** `tiene_observaciones`
- Registro en `programacion.module.ts`