### PR TITLE
feat: Agregar sufijo OCI a descarga de documentos en planeación

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -284,7 +284,8 @@ export class TablaAuditoriasInternasComponent implements OnInit {
           { nombre: "Compromiso ético", tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.COMPROMISO_ETICO },
         ],
         titulo: `${tituloYSubtituloAuditoria(auditoria)}`,
-        descripcion: `Documentos asociados a la auditoría`
+        descripcion: `Documentos asociados a la auditoría`,
+        sufijo: `oci-${auditoria.consecutivo_OCI}`,
       },
       autoFocus: false,
     });

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
@@ -459,6 +459,7 @@ export class TablaSeguimientoComponent implements OnInit {
       data: {
         entityId: auditoriaId,
         descripcion: "Documentos de la Auditoría de Seguimiento",
+        sufijo: `oci-${auditoria.consecutivo_OCI}`,
         tabs: [
           {
             nombre: "Oficio Anuncio Solicitud de Información",

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan.auditoria.utils.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan.auditoria.utils.ts
@@ -289,7 +289,7 @@ export class DocumentoUtils {
         entityId: planId,
         descripcion: `Documentos asociados al Plan Anual de Auditoría - Vigencia ${planVigenciaNombre}`,
         tabs: tabs,
-        vigenciaNombre: planVigenciaNombre,
+        sufijo: planVigenciaNombre,
       },
     });
   }

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
@@ -55,7 +55,7 @@ export interface ModalVerDocumentosData {
   entityId: string;
   titulo?: string;
   descripcion?: string;
-  vigenciaNombre?: string;
+  sufijo?: string;
   tabs?: TabDocumento[];
   inferTabs?: boolean;
   tipo?: number;
@@ -75,7 +75,7 @@ export class ModalVerDocumentosComponent implements OnInit {
 
   titulo: string = "Ver documentos";
   descripcion: string = "Documentos";
-  vigenciaSuffix: string = "";
+  suffix: string = "";
   textoBotonCerrar: string = "Regresar";
   consultarPorTipo: boolean = false;
   tabs: TabDocumento[] = [];
@@ -94,10 +94,8 @@ export class ModalVerDocumentosComponent implements OnInit {
     if (data.tabs) this.tabs = data.tabs;
     if (data.textoBotonCerrar) this.textoBotonCerrar = data.textoBotonCerrar;
     if (data.tipo) this.consultarPorTipo = true;
-    if (data.vigenciaNombre) {
-      this.vigenciaSuffix = data.vigenciaNombre
-          ? `-${data.vigenciaNombre.replace(/\s+/g, '-')}`
-          : '';
+    if (data.sufijo) {
+      this.suffix = data.sufijo ? data.sufijo : '';
     }
   }
 
@@ -286,11 +284,12 @@ export class ModalVerDocumentosComponent implements OnInit {
   }
 
   async descargarTodo() {
+    const suffixNormalizado = this.suffix ? `-${this.suffix.replace(/\s+/g, '-')}` : '';
     try {
       await this.descargaService.descargarMultiplesArchivos(
         this.documentos,
-        `documentos${this.vigenciaSuffix}.zip`,
-        this.vigenciaSuffix,
+        `documentos${suffixNormalizado}.zip`,
+        this.suffix,
       );
     } catch (error) {
       console.error("Error al crear el archivo ZIP:", error);

--- a/src/app/shared/services/descarga.service.ts
+++ b/src/app/shared/services/descarga.service.ts
@@ -80,7 +80,7 @@ export class DescargaService {
   ): Promise<void> {
     const zip = new JSZip();
     const nombreBaseContador = new Map<string, number>();
-    const suffixNormalizado = suffix ? `-${suffix}` : '';
+    const suffixNormalizado = suffix ? `-${suffix.replace(/\s+/g, '-')}` : '';
   
     try {
       documentos.forEach((doc, index) => {


### PR DESCRIPTION
This pull request updates the way document-related modals handle and display suffixes for file downloads, replacing the previous `vigenciaNombre` property with a more general `sufijo` (suffix) property throughout the application. The changes ensure a consistent and flexible approach to naming downloaded files and referencing document sets, accommodating various contexts such as audit cycles and plan years.

Answers:

- udistrital/sisifo_documentacion#757

**Key changes:**

**Refactoring and property updates:**
- Replaced the `vigenciaNombre` property with a more generic `sufijo` property in the `ModalVerDocumentosData` interface and all related components and utilities, allowing for broader use cases beyond just plan years. [[1]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL58-R58) [[2]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL97-R98) [[3]](diffhunk://#diff-66c95a537a4b1e22ed79b489c34ca209c7def9b188c7e8f8e82547cbca174428L292-R292)

**Component and modal adjustments:**
- Updated `ModalVerDocumentosComponent` to use the new `suffix` property for file naming and internal logic, including normalizing the suffix for ZIP downloads and removing references to the old `vigenciaSuffix`. [[1]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bL78-R78) [[2]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bR287-R292)

**Contextual suffix assignment:**
- Passed the appropriate `sufijo` value (such as `oci-${auditoria.consecutivo_OCI}` or the plan year) when opening document modals from audit and plan components, ensuring accurate and meaningful file names for users. [[1]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L287-R288) [[2]](diffhunk://#diff-97e211436768ecd00b08f88c08c7f75201c9271265d877d77f6420a2614c7acbR462) [[3]](diffhunk://#diff-66c95a537a4b1e22ed79b489c34ca209c7def9b188c7e8f8e82547cbca174428L292-R292)

**File download improvements:**
- In `DescargaService`, normalized the suffix by replacing spaces with hyphens before appending it to ZIP file names, resulting in cleaner and more predictable filenames.