### PR TITLE
feat: Generación y asignación inmediata de una única auditoría especial concreta

### DIFF
--- a/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.component.ts
+++ b/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.component.ts
@@ -306,13 +306,13 @@ export class TablaAuditoriasEspecialesComponent {
           
           return res.Data.map(
             (item: Auditoria, index: number): AuditoriaEspecialTablaRow => {
-              const numeroConcreto = `${numeroPadre}.${index + 1}`;
+              const numeroConcreto = `${index + 1}`;
               return {
-                numero: numeroConcreto,
+                numero: "",
                 _id: item._id || `${padreId}-concreta-${index + 1}`,
                 auditoria_padre_id: padreId,
                 titulo: item.titulo || "Sin Titulo",
-                subtitulo: item.subtitulo || "",
+                subtitulo: item.subtitulo || `Sin Subtítulo (#${numeroConcreto})`,
                 tipo_evaluacion_id: item.tipo_evaluacion_id || 0,
                 tipo_evaluacion_nombre: item.tipo_evaluacion_nombre || "Sin Asignar",
                 cronograma_id: item.cronograma_id || [],

--- a/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.component.ts
+++ b/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.component.ts
@@ -14,7 +14,8 @@ import {
   AuditoriaEspecialTablaRow,
   colocacionesContructorTablaEspeciales,
 } from "./tabla-auditorias-especiales.utilidades";
-import { catchError, firstValueFrom, map, Observable, of } from 'rxjs';
+import { catchError, firstValueFrom, map, Observable, of, throwError } from 'rxjs';
+import { error } from 'node:console';
 
 @Component({
   selector: 'app-tabla-auditorias-especiales',
@@ -161,12 +162,49 @@ export class TablaAuditoriasEspecialesComponent {
       },
     });
 
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result?.saved) {
-        const offset = this.pageIndex * this.pageSize;
-        this.cargarAuditorias(this.vigenciaId!, this.pageSize, offset);
+    dialogRef.afterClosed().subscribe(async (result) => {
+      if (!result?.saved)
+        return;
+
+      // Si la cantidad de auditorías concretas es 1, se inicia el proceso de generación y asignación automática, de lo contrario se recarga la tabla normalmente.
+      const offset = this.pageIndex * this.pageSize;
+      if (result.cantidad == 1) {
+        try {
+          await this.generarYAsignarUnicaAuditoriaConcreta(auditoria!);
+        } catch (error) {
+          console.error("Error al generar y asignar auditoría concreta:", error);
+          this.alertaService.showErrorAlert("Error al generar y asignar auditoría concreta");
+        }
       }
+
+      this.cargarAuditorias(this.vigenciaId!, this.pageSize, offset);
     });
+  }
+
+  async generarYAsignarUnicaAuditoriaConcreta(auditoriaPadre: AuditoriaEspecialTablaRow): Promise<void> {
+    // Primero se comprueba que no existen auditorías concretas
+    let auditoriasConcretas = await this.traerAuditoriasConcretas(auditoriaPadre);
+    if (auditoriasConcretas.length > 0)
+      return;
+
+    // Luego se genera la nueva auditoría concreta
+    await firstValueFrom(
+      this.planAuditoriaService.post(
+        `auditoria-padre/${auditoriaPadre._id}/generar-auditoria`, {}
+      ).pipe(
+        catchError((error) => throwError(() =>
+          new Error("Error al generar la auditoría concreta.", error)
+        ))
+      )
+    );
+
+    // Ahora se cargan las auditorías concretas para obtener los campos enriquecidos
+    auditoriasConcretas = await this.traerAuditoriasConcretas(auditoriaPadre);
+    if (auditoriasConcretas.length !== 1)
+      throw new Error("Error inesperado: se esperaba exactamente una auditoría concreta después de la generación.");
+
+    // Finalmente se abre el modal de asignación con la auditoría concreta recién generada.
+    this.editarAuditoriaConcreta(auditoriasConcretas[0]);
   }
 
   enviaraAuditor(auditoria: Auditoria) {

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/registrar-auditorias/add-auditoria-modal/add-auditoria-modal.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/registrar-auditorias/add-auditoria-modal/add-auditoria-modal.component.ts
@@ -306,7 +306,11 @@ export class AddAuditoriaModalComponent implements OnInit {
         this.isEditMode ? "actualizada" : "guardada"
       } exitosamente.`
     );
-    this.dialogRef.close({ saved: true, nuevoEstado });
+    this.dialogRef.close({
+      saved: true,
+      cantidad: this.auditoriaForm.value.cantidadAuditorias,
+      nuevoEstado,
+    });
   }
 
 }


### PR DESCRIPTION
This pull request enhances the workflow for creating and assigning "auditorías concretas" (concrete audits) in the special audits table component. The main improvement is the automation of generating and assigning a single concrete audit when only one is created, streamlining the user experience. Additionally, there are some minor adjustments to how concrete audit rows are displayed and error handling improvements.

Answers:

- udistrital/sisifo_documentacion#756

**Automated generation and assignment of single concrete audit:**

- When the user creates a single concrete audit via the modal, the system now automatically generates it, fetches its enriched data, and opens the assignment modal for the new audit. This is handled by the new `generarYAsignarUnicaAuditoriaConcreta` method, which includes error handling and ensures no audit is present before proceeding.

**Dialog and data flow improvements:**

- The modal dialog now returns both the `saved` status and the number of audits in the process (`cantidad`), allowing the parent component to determine whether to trigger the automated workflow or just reload the table.

**Error handling and imports:**

- Improved error handling by importing `throwError` from `rxjs` and using it in the new method for more robust error propagation.

**Display adjustments for concrete audit rows:**

- Modified the construction of concrete audit row numbers and subtitles: the `numero` field is now set to an empty string, and the subtitle includes a fallback with the concrete audit's number for clarity.