### PR TITLE
fix: se corrige pérdida de vigencia y título en encabezado al guardarpaso 1 de editar auditoría, se reemplaza reasignación completa de auditoria por merge con spread operator para conservar campos enriquecidos del MID udistrital/sisifo_documentacion#753

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
@@ -182,15 +182,20 @@ export class EditarAuditoriaComponent implements OnInit, AfterViewInit {
     this.planAuditoriaService
       .put(`auditoria/${auditoriaId}`, informacionEditar)
       .subscribe((res) => {
+        const datosActualizados = (res as any)?.Data;
+        if (datosActualizados) {
+          this.auditoria = { ...this.auditoria, ...datosActualizados };
+        }
+
         if (this.auditoria.estado_id !== environment.AUDITORIA_ESTADO.PLANEACION.CREANDO_PROGRAMA) {
           this.cambiarEstado().subscribe(() => {
             this.auditoria.estado_id = environment.AUDITORIA_ESTADO.PLANEACION.CREANDO_PROGRAMA;
-            this.alertaService.showSuccessAlert(
-              "Información editada correctamente"
-            );
+            this.alertaService.showSuccessAlert("Información editada correctamente");
           });
+        } else {
+          this.alertaService.showSuccessAlert("Información editada correctamente");
         }
-        this.auditoria = (res as any).Data;
+
         this.paso1Guardado = true;
         this.stepper.next();
       });


### PR DESCRIPTION
## Descripción
Corrección de pérdida de `vigencia_nombre` y `titulo` en el encabezado del componente `editar-auditoria` al guardar el Paso 1.

## Problema
Al ejecutar `guardarInformacion`, se reasignaba `this.auditoria` con la respuesta directa del PUT al CRUD. Dicha respuesta no pasa por el MID, por lo que no contiene campos enriquecidos como `vigencia_nombre` y `titulo`, causando que el encabezado desapareciera al avanzar al Paso 2.

## Solución
Se reemplazó `this.auditoria = (res as any).Data` por un merge con spread operator:
```typescript
this.auditoria = { ...this.auditoria, ...datosActualizados };
```
Esto conserva los campos enriquecidos del MID y actualiza correctamente los campos editados.

## Archivos modificados
- `editar-auditoria.component.ts`