### PR TITLE
fix: Guardado de carta de representación y sincronización metadato "firmado"

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
@@ -445,7 +445,6 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
     }
 
     const modalInstance = dialogRef.componentInstance;
-    const metadatos = { firmado: false };
     modalInstance.botonGuardar = { icono: "save", texto: "Guardar carta actual" };
     modalInstance.botonGuardarTodos = { icono: "save", texto: "Guardar todas" };
     modalInstance.onGuardarIndividual = (indice: number) => {
@@ -453,7 +452,6 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
         documentos[indice].base64,
         this.construirInfoCarta(infoDocumento, documentos[indice]),
         () => modalInstance.marcarGuardado(indice),
-        metadatos
       );
     };
     modalInstance.onGuardarTodos = () => {
@@ -462,7 +460,6 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
           documentoCarta.base64,
           this.construirInfoCarta(infoDocumento, documentoCarta),
           () => modalInstance.marcarGuardado(indice),
-          metadatos
         );
       });
     };
@@ -504,7 +501,6 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
     documentoBase64: any,
     infoDocumento: any,
     onSuccess?: () => void,
-    metadatos?: Record<string, any>,
   ) {
     if (this.soloLectura) {
       return;
@@ -518,7 +514,6 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
           "Documento pdf (" +
           infoDocumento.plantilla +
           ") de auditoría de plan de auditoría",
-        metadatos: metadatos,
         file: documentoBase64,
       };
 
@@ -533,7 +528,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit {
             this.auditoriaId,
             infoDocumento.parametro,
             this.esCartaRepresentacion(infoDocumento)
-              ? { dependencia_id: infoDocumento.dependenciaId }
+              ? { dependencia_id: infoDocumento.dependenciaId, firmado: false }
               : undefined,
             () => {
               if (this.esCartaRepresentacion(infoDocumento)) {

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -115,7 +115,7 @@ export class RevisionDocumentosComponent implements OnInit {
 
   verificarFirmaCartaYPreguntarAprobacion(cartas: DocumentoAdjuntoRevision[]) {
     for (const carta of cartas) {
-      if (!carta.metadatos!["firmada"]) {
+      if (!carta.metadatos!["firmado"]) {
         this.alertService.showAlert(
           "Carta sin firmar",
           `La carta de representación para la dependencia ${this.resolverNombreDependencia(carta, 0)} no ha sido cargada con firma. Por favor, cargue la carta firmada antes de aprobar la auditoría.`
@@ -319,7 +319,7 @@ export class RevisionDocumentosComponent implements OnInit {
             idTipoDocumento: environment.TIPO_DOCUMENTO.PROGRAMA_TRABAJO_AUDITORIA,
             descripcion: `Carta de representación firmada - ${dependenciaNombre}`,
             referenciaTipoFallback: "Auditoria",
-            metadatosAdicionales: { firmada: true },
+            metadatosAdicionales: { firmado: true },
             onSuccess: async () => {
               cartasAuditado = await this.cargarCartasAuditado();
               this.cargarDocumentos();

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -358,7 +358,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
           cargueAdjuntoConfig: cargueAdjuntoConfig
             ? {
                 ...cargueAdjuntoConfig,
-                metadatosAdicionales: { firmada: true},
+                metadatosAdicionales: { firmado: true},
               }
             : undefined,
         }


### PR DESCRIPTION
This pull request standardizes the use of the `firmado` metadata property (instead of `firmada`) throughout the auditoría document handling components, and refactors how metadata is passed and handled when saving documents. The changes ensure consistency in metadata naming and simplify the document saving logic.

- udistrital/sisifo_documentacion#767

**Metadata property standardization:**

* Updated all references from `firmada` to `firmado` in metadata objects and checks, ensuring consistent use of the property across components such as `RevisionDocumentosComponent` and `TablaAuditoriasInternasComponent`. [[1]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acL118-R118) [[2]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acL322-R322) [[3]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L361-R361)

**Refactoring document saving logic:**

* Removed the explicit `metadatos` parameter from the `guardarDocumento` method and its invocations, simplifying the method signature and its usage in `DocumentosAnexosAuditoriaComponent`. [[1]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9L448-L456) [[2]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9L465) [[3]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9L507) [[4]](diffhunk://#diff-60e49bba635375ce9bd22f251c75e5a192f017e6c86fecdd0084a2f05c1905f9L521)
* When saving a carta de representación, now directly includes `{ dependencia_id, firmado: false }` in the parameters instead of passing a separate `metadatos` object.