### PR TITLE
fix: No deduplicar cartas de representación en revisión de planeación

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -274,7 +274,9 @@ export class RevisionDocumentosComponent implements OnInit {
 
   async cargarCartasAuditado() {
       const cartas = (await lastValueFrom(
-        this.referenciaPdfService.consultarDocumentos(this.auditoriaId, {})
+        this.referenciaPdfService.consultarDocumentos(this.auditoriaId, {
+          deduplicarPorTipo: false,
+        })
       )) as DocumentoAdjuntoRevision[];
 
       return cartas.filter(
@@ -374,7 +376,9 @@ export class RevisionDocumentosComponent implements OnInit {
       this.filtrarDocumentosPorDependenciaAuditado(tipoDocumentoMap);
     } else {
       this.referenciaPdfService
-        .consultarDocumentos(this.auditoriaId, {})
+        .consultarDocumentos(this.auditoriaId, {
+          deduplicarPorTipo: false,
+        })
         .subscribe(async (documentosAdjuntos: DocumentoReferenciaPdf[]) => {
           await this.cargarDependenciasPorAuditoria();
 


### PR DESCRIPTION
This pull request makes a minor update to how documents are fetched in the `RevisionDocumentosComponent`. The main change is to explicitly set the `deduplicarPorTipo` option to `false` when calling the `consultarDocumentos` method, ensuring that documents are not deduplicated by type during retrieval.

- udistrital/sisifo_documentacion#767

**Changes:**

  * Updated both the `cargarCartasAuditado` method and another call in `RevisionDocumentosComponent` to pass `{ deduplicarPorTipo: false }` as an argument to `referenciaPdfService.consultarDocumentos`, ensuring that all document types are returned without deduplication. [[1]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acL277-R279) [[2]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acL377-R381)