### PR TITLE
feat: integrar formulario con CRUD de planes y acciones udistrital/sisifo_documentacion/issues/747

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "bootstrap": "^5.3.0",
         "crypto-js": "^4.2.0",
         "date-fns": "^4.1.0",
+        "date-holidays": "^3.28.0",
         "file-saver": "^2.0.5",
         "jszip": "^3.10.1",
         "ng2-pdf-viewer": "^10.3.1",
@@ -8071,7 +8072,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -8090,6 +8090,15 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/astronomia": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/astronomia/-/astronomia-4.2.0.tgz",
+      "integrity": "sha512-mTvpBGyXB80aSsDhAAiuwza5VqAyqmj5yzhjBrFhRy17DcWDzJrb8Vdl4Sm+g276S+mY7bk/5hi6akZ5RQFeHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
@@ -8598,6 +8607,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/caldate": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/caldate/-/caldate-2.0.5.tgz",
+      "integrity": "sha512-JndhrUuDuE975KUhFqJaVR1OQkCHZqpOrJur/CFXEIEhWhBMjxO85cRSK8q4FW+B+yyPq6GYua2u4KvNzTcq0w==",
+      "license": "ISC",
+      "dependencies": {
+        "moment-timezone": "^0.5.43"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -9411,6 +9432,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/date-bengali-revised": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/date-bengali-revised/-/date-bengali-revised-2.0.2.tgz",
+      "integrity": "sha512-q9iDru4+TSA9k4zfm0CFHJj6nBsxP7AYgWC/qodK/i7oOIlj5K2z5IcQDtESfs/Qwqt/xJYaP86tkazd/vRptg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-chinese": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/date-chinese/-/date-chinese-2.1.4.tgz",
+      "integrity": "sha512-WY+6+Qw92ZGWFvGtStmNQHEYpNa87b8IAQ5T8VKt4wqrn24lBXyyBnWI5jAIyy7h/KVwJZ06bD8l/b7yss82Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "astronomia": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-easter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/date-easter/-/date-easter-1.0.3.tgz",
+      "integrity": "sha512-aOViyIgpM4W0OWUiLqivznwTtuMlD/rdUWhc5IatYnplhPiWrLv75cnifaKYhmQwUBLAMWLNG4/9mlLIbXoGBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -9429,6 +9480,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/date-holidays": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/date-holidays/-/date-holidays-3.28.0.tgz",
+      "integrity": "sha512-TNrzyzO5JWght5RLzKek8No1vme6vL3pnXl6LwWCPEPgENQiuXi/xvGIgOdmX8hWQml29SRn8sz3/BpNyAb/ew==",
+      "license": "(ISC AND CC-BY-3.0)",
+      "dependencies": {
+        "date-holidays-parser": "^3.4.7",
+        "js-yaml": "^4.1.1",
+        "lodash": "^4.17.23",
+        "prepin": "^1.0.3"
+      },
+      "bin": {
+        "holidays2json": "scripts/holidays2json.cjs"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/date-holidays-parser": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/date-holidays-parser/-/date-holidays-parser-3.4.7.tgz",
+      "integrity": "sha512-h09ZEtM6u5cYM6m1bX+1Ny9f+nLO9KVZUKNPEnH7lhbXYTfqZogaGTnhONswGeIJFF91UImIftS3CdM9HLW5oQ==",
+      "license": "ISC",
+      "dependencies": {
+        "astronomia": "^4.1.1",
+        "caldate": "^2.0.5",
+        "date-bengali-revised": "^2.0.2",
+        "date-chinese": "^2.1.4",
+        "date-easter": "^1.0.3",
+        "deepmerge": "^4.3.1",
+        "jalaali-js": "^1.2.7",
+        "moment-timezone": "^0.5.47"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/debug": {
@@ -9481,6 +9569,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -11981,6 +12078,12 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jalaali-js": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/jalaali-js/-/jalaali-js-1.2.8.tgz",
+      "integrity": "sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A==",
+      "license": "MIT"
+    },
     "node_modules/jasmine-core": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.6.1.tgz",
@@ -12144,7 +12247,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12893,7 +12995,6 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -13576,6 +13677,27 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -15004,6 +15126,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prepin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/prepin/-/prepin-1.0.3.tgz",
+      "integrity": "sha512-0XL2hreherEEvUy0fiaGEfN/ioXFV+JpImqIzQjxk6iBg4jQ2ARKqvC4+BmRD8w/pnpD+lbxvh0Ub+z7yBEjvA==",
+      "license": "Unlicense",
+      "bin": {
+        "prepin": "bin/prepin.js"
       }
     },
     "node_modules/prettier": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bootstrap": "^5.3.0",
     "crypto-js": "^4.2.0",
     "date-fns": "^4.1.0",
+    "date-holidays": "^3.28.0",
     "file-saver": "^2.0.5",
     "jszip": "^3.10.1",
     "ng2-pdf-viewer": "^10.3.1",

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/modal-registrar-accion/modal-registrar-accion.component.ts
@@ -1,17 +1,20 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { PlanAnualAuditoriaService } from 'src/app/core/services/plan-anual-auditoria.service';
+import { OikosService } from 'src/app/core/services/oikos.service';
 import { AlertService } from 'src/app/shared/services/alert.service';
-import { AccionPlan } from '../tabla-hallazgos/tabla-hallazgos.component';
+import { AccionPlan, ResultadoModalAccion } from '../tabla-hallazgos/tabla-hallazgos.component';
 
 export interface DatosModalAccion {
   hallazgo: any;
   accion: AccionPlan | null;
   auditoria: any;
+  planMejoramientoId: string;
 }
 
 export interface Dependencia {
-  id: string;
+  id: number;
   nombre: string;
 }
 
@@ -23,23 +26,17 @@ export interface Dependencia {
 export class ModalRegistrarAccionComponent implements OnInit {
   form!: FormGroup;
   modoEdicion = false;
-  /** Nombre de la dependencia líder (read-only, viene de la auditoría) */
   dependenciaLider = '';
 
-  /** Lista de dependencias disponibles para seleccionar (mock para pruebas) */
-  dependenciasDisponibles: Dependencia[] = [
-    { id: '1', nombre: 'Oficina de Control Interno' },
-    { id: '2', nombre: 'Gestión de Docencia' },
-    { id: '3', nombre: 'Gestión de Bienestar' },
-    { id: '4', nombre: 'Gestión Financiera' },
-    { id: '5', nombre: 'Gestión de TI' },
-  ];
-
-  /** Dependencia actualmente seleccionada en el dropdown */
+  todasDependencias: Dependencia[] = [];
+  dependenciasDisponibles: Dependencia[] = [];
   responsableSeleccionado: Dependencia | null = null;
-
-  /** Responsables ya agregados (se muestran como chips) */
   responsablesAgregados: Dependencia[] = [];
+
+  private responsablesActuales: { _id: string; dependencia_id: number; dependencia_lider: boolean }[] = [];
+
+  cargandoDependencias = false;
+
   tiposAccion = [
     { id: 1, nombre: 'Preventiva' },
     { id: 2, nombre: 'Correctiva' },
@@ -67,18 +64,21 @@ export class ModalRegistrarAccionComponent implements OnInit {
     private readonly dialogRef: MatDialogRef<ModalRegistrarAccionComponent>,
     private readonly fb: FormBuilder,
     private readonly alertService: AlertService,
+    private readonly planAuditoriaService: PlanAnualAuditoriaService,
+    private readonly oikosService: OikosService,
   ) {}
 
   ngOnInit(): void {
     this.modoEdicion = !!this.data.accion;
     this.iniciarForm();
-    this.iniciarResponsables();
+    this.iniciarDependenciaLider();
+    this.cargarDependencias();
     if (this.modoEdicion) this.poblarForm();
   }
 
   private iniciarForm(): void {
     this.form = this.fb.group({
-      causa:            ['', Validators.required],
+      causa:            [this.data.hallazgo?.causa ?? '', Validators.required],
       tipoAccion:       ['', Validators.required],
       accionPlanteada:  ['', Validators.required],
       nombreIndicador:  [''],
@@ -87,57 +87,79 @@ export class ModalRegistrarAccionComponent implements OnInit {
     });
   }
 
-  private iniciarResponsables(): void {
-    // Dependencia líder viene de la auditoría (read-only)
+  private iniciarDependenciaLider(): void {
     this.dependenciaLider =
       this.data.auditoria?.jefe_nombre ??
       this.data.auditoria?.dependencia_nombre ??
       '';
   }
 
+  private cargarDependencias(): void {
+    this.cargandoDependencias = true;
+    this.oikosService.get('dependencia?limit=0&query=Activo:true').subscribe({
+      next: (res: any) => {
+        const lista: any[] = Array.isArray(res) ? res : (res.Data ?? []);
+        this.todasDependencias = lista.map((d: any) => ({
+          id:     d.Id ?? d.id,
+          nombre: d.Nombre ?? d.nombre,
+        }));
+        this.actualizarDisponibles();
+        this.cargandoDependencias = false;
+
+        if (this.modoEdicion) this.cargarResponsablesExistentes();
+      },
+      error: () => { this.cargandoDependencias = false; }
+    });
+  }
+
+  private cargarResponsablesExistentes(): void {
+    const accionId = this.data.accion?.accionId;
+    if (!accionId) return;
+
+    this.planAuditoriaService
+      .get(`responsable-accion?query=accion_mejora_id:${accionId},activo:true`)
+      .subscribe({
+        next: (res) => {
+          this.responsablesActuales = res.Data ?? [];
+          // Mostrar en UI solo los que NO son líderes
+          const dependenciasActuales = this.responsablesActuales.filter(r => !r.dependencia_lider);
+          this.responsablesAgregados = dependenciasActuales.map(r => {
+            const dep = this.todasDependencias.find(d => d.id === r.dependencia_id);
+            return { id: r.dependencia_id, nombre: dep?.nombre ?? `Dependencia ${r.dependencia_id}` };
+          });
+          this.actualizarDisponibles();
+        },
+        error: () => {}
+      });
+  }
+
   private poblarForm(): void {
     const a = this.data.accion!;
     this.form.patchValue({
-      causa:            a.tipoAccion,
-      tipoAccion:       a.tipoAccion,
+      causa:            this.data.hallazgo?.causa ?? '',
+      tipoAccion:       a.tipoAccionId ?? '',
       accionPlanteada:  a.accionPlanteada,
       nombreIndicador:  a.nombreIndicador,
       formulaIndicador: a.formulaIndicador,
       meta:             a.meta,
     });
+  }
 
-    // Restaurar responsables guardados en la acción
-    if (a.responsable) {
-      this.responsablesAgregados = [{ id: '0', nombre: a.responsable }];
-    }
+  private actualizarDisponibles(): void {
+    const idsAgregados = new Set(this.responsablesAgregados.map(r => r.id));
+    this.dependenciasDisponibles = this.todasDependencias.filter(d => !idsAgregados.has(d.id));
   }
 
   agregarResponsable(): void {
     if (!this.responsableSeleccionado) return;
-
-    const yaExiste = this.responsablesAgregados.some(
-      r => r.id === this.responsableSeleccionado!.id
-    );
-    if (yaExiste) {
-      this.alertService.showAlert(
-        'Responsable duplicado',
-        'Esta dependencia ya fue agregada como responsable.'
-      );
-      return;
-    }
-
     this.responsablesAgregados = [...this.responsablesAgregados, { ...this.responsableSeleccionado }];
-    this.dependenciasDisponibles = this.dependenciasDisponibles.filter(
-      d => d.id !== this.responsableSeleccionado!.id
-    );
     this.responsableSeleccionado = null;
+    this.actualizarDisponibles();
   }
 
   eliminarResponsable(index: number): void {
-    const eliminado = this.responsablesAgregados[index];
-    // Devolver al dropdown
-    this.dependenciasDisponibles = [...this.dependenciasDisponibles, eliminado];
     this.responsablesAgregados = this.responsablesAgregados.filter((_, i) => i !== index);
+    this.actualizarDisponibles();
   }
 
   guardarYCerrar(): void {
@@ -148,35 +170,58 @@ export class ModalRegistrarAccionComponent implements OnInit {
     }
 
     if (this.responsablesAgregados.length === 0) {
-      this.alertService.showAlert(
-        'Sin responsables',
-        'Debe agregar al menos un responsable de la acción.'
-      );
+      this.alertService.showAlert('Sin responsables', 'Debe agregar al menos un responsable de la acción.');
       return;
     }
 
-    this.alertService
-      .showConfirmAlert('¿Guardar cambios?')
-      .then((confirmado) => {
-        if (!confirmado.value) return;
+    this.alertService.showConfirmAlert('¿Guardar cambios?').then(conf => {
+      if (!conf.value) return;
 
-        const v = this.form.value;
+      const v = this.form.value;
+      const liderDependenciaId: number = this.data.auditoria?.dependencia_id ?? 0;
 
-        const accionGuardada: AccionPlan = {
-          numero:           this.data.accion?.numero ?? '',
-          tipoAccion:       this.tiposAccion.find(t => t.id === v.tipoAccion)?.nombre ?? v.tipoAccion,
+      // IDs de dependencias (no-lider) que ya estaban en DB
+      const idsActualesNoLider = new Set(
+        this.responsablesActuales
+          .filter(r => !r.dependencia_lider)
+          .map(r => r.dependencia_id)
+      );
+      const idsEnUI = new Set(this.responsablesAgregados.map(r => r.id));
+
+      // Registros a eliminar: estaban en DB pero el usuario los quitó
+      const responsablesAEliminar = this.responsablesActuales
+        .filter(r => !r.dependencia_lider && !idsEnUI.has(r.dependencia_id))
+        .map(r => r._id);
+
+      const responsablesNuevos: { dependencia_id: number; dependencia_lider: boolean }[] = [];
+
+      // En creación: incluir la dependencia líder solo si tiene ID válido
+      if (!this.modoEdicion && liderDependenciaId) {
+        responsablesNuevos.push({ dependencia_id: liderDependenciaId, dependencia_lider: true });
+      }
+
+      // Dependencias que el usuario agregó y no estaban en DB
+      this.responsablesAgregados.forEach(r => {
+        if (!idsActualesNoLider.has(r.id)) {
+          responsablesNuevos.push({ dependencia_id: r.id, dependencia_lider: false });
+        }
+      });
+
+      const resultado: ResultadoModalAccion = {
+        accion: {
+          accionId:         this.data.accion?.accionId,
+          tipoAccionId:     v.tipoAccion,
           accionPlanteada:  v.accionPlanteada,
           nombreIndicador:  v.nombreIndicador,
           formulaIndicador: v.formulaIndicador,
           meta:             v.meta,
-          // Concatenar nombres de responsables si hay varios
-          responsable:      this.responsablesAgregados.map(r => r.nombre).join(', '),
-          fechaInicio:      '',
-          fechaFin:         '',
-        };
+        },
+        responsablesNuevos,
+        responsablesAEliminar,
+      };
 
-        this.alertService.showSuccessAlert('Acción guardada correctamente.', 'Guardado');
-        this.dialogRef.close(accionGuardada);
-      });
+      this.alertService.showSuccessAlert('Acción guardada correctamente.', 'Guardado');
+      this.dialogRef.close(resultado);
+    });
   }
 }

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.html
@@ -56,8 +56,9 @@
     </div>
     <div class="col-12">
       <app-tabla-hallazgos
-        *ngIf="auditoria"
+        *ngIf="auditoria && planMejoramientoId"
         [auditoriaId]="auditoriaId"
+        [planMejoramientoId]="planMejoramientoId"
         [auditoria]="auditoria"
       ></app-tabla-hallazgos>
     </div>
@@ -65,15 +66,16 @@
 
 <!-- Footer -->
     <div class="d-flex justify-content-end mt-4" style="gap: 16px;">
-    <button mat-raised-button color="primary">
-        <mat-icon>visibility</mat-icon>
-        Vista Previa
-    </button>
-    <button mat-raised-button color="primary">Guardar</button>
-    <button mat-stroked-button color="primary">
+      <button mat-raised-button color="primary" (click)="guardar()">
+        <mat-icon>save</mat-icon>
+        Guardar
+      </button>
+      <button mat-stroked-button color="primary"
+              (click)="enviarAuditor()"
+              [disabled]="enviando || !planMejoramientoId">
         <mat-icon>send</mat-icon>
         Enviar a Auditor
-    </button>
+      </button>
     </div>
 
 </ng-template>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.ts
@@ -1,6 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PlanAnualAuditoriaMid } from 'src/app/core/services/plan-anual-auditoria-mid.service';
+import { PlanAnualAuditoriaService } from 'src/app/core/services/plan-anual-auditoria.service';
+import { AlertService } from 'src/app/shared/services/alert.service';
+import { RolService } from 'src/app/core/services/rol.service';
+import { UserService } from 'src/app/core/services/user.service';
+import { sumarDiasHabiles } from 'src/app/shared/utils/dias-habiles.util';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-registrar-plan',
@@ -10,16 +16,34 @@ import { PlanAnualAuditoriaMid } from 'src/app/core/services/plan-anual-auditori
 export class RegistrarPlanComponent implements OnInit {
   auditoriaId!: string;
   auditoria: any = null;
+  planMejoramientoId: string | null = null;
   cargando = true;
+  enviando = false;
+
+  private usuarioId = 0;
+  private role: string | null = null;
 
   constructor(
     private readonly route: ActivatedRoute,
     private readonly router: Router,
     private readonly planAuditoriaMid: PlanAnualAuditoriaMid,
+    private readonly planAuditoriaService: PlanAnualAuditoriaService,
+    private readonly alertService: AlertService,
+    private readonly rolService: RolService,
+    private readonly userService: UserService,
   ) {}
 
-  ngOnInit(): void {
+  async ngOnInit(): Promise<void> {
     this.auditoriaId = this.route.snapshot.paramMap.get('id')!;
+    this.role = this.rolService.getRolPrioritario([
+      environment.ROL.JEFE,
+      environment.ROL.AUDITOR_EXPERTO,
+      environment.ROL.AUDITOR,
+      environment.ROL.AUDITOR_ASISTENTE,
+      environment.ROL.JEFE_DEPENDENCIA,
+      environment.ROL.ASISTENTE_DEPENDENCIA,
+    ]);
+    this.usuarioId = await this.userService.getPersonaId();
     this.cargarAuditoria();
   }
 
@@ -27,13 +51,114 @@ export class RegistrarPlanComponent implements OnInit {
     this.planAuditoriaMid.get(`auditoria/${this.auditoriaId}`).subscribe({
       next: (res) => {
         this.auditoria = res.Data;
-        this.cargando = false;
+        this.resolverPlanMejoramiento();
       },
       error: () => { this.cargando = false; }
     });
   }
 
+  private resolverPlanMejoramiento(): void {
+    this.planAuditoriaService
+      .get(`plan-mejoramiento?query=auditoria_id:${this.auditoriaId},activo:true`)
+      .subscribe({
+        next: (res) => {
+          if (res.Data?.length) {
+            this.planMejoramientoId = res.Data[0]._id;
+            this.cargando = false;
+          } else {
+            this.crearPlanMejoramiento();
+          }
+        },
+        error: () => { this.cargando = false; }
+      });
+  }
+
+  private crearPlanMejoramiento(): void {
+    const fechaApertura = new Date();
+    const body = {
+      auditoria_id:       this.auditoriaId,
+      vigencia_id:        this.auditoria?.vigencia_id,
+      tipo_evaluacion_id: this.auditoria?.tipo_evaluacion_id,
+      fecha_apertura:     fechaApertura.toISOString(),
+      fecha_limite:       sumarDiasHabiles(fechaApertura, 8).toISOString(),
+      estado_id:          environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO,
+      activo:             true,
+    };
+
+    this.planAuditoriaService.post('plan-mejoramiento', body).subscribe({
+      next: (res: any) => {
+        this.planMejoramientoId = res.Data._id;
+        this.registrarEstadoInicial(res.Data._id);
+      },
+      error: () => {
+        this.alertService.showErrorAlert('Error al crear el plan de mejoramiento.');
+        this.cargando = false;
+      }
+    });
+  }
+
+  private registrarEstadoInicial(planId: string): void {
+    const body = {
+      plan_mejoramiento_id:   planId,
+      usuario_id:             this.usuarioId,
+      usuario_rol:            this.role,
+      observacion:            'Plan de mejoramiento iniciado',
+      estado_id:              environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO,
+      fase_id:                environment.AUDITORIA_FASE.PLAN_MEJORAMIENTO,
+      fecha_ejecucion_estado: new Date().toISOString(),
+      activo:                 true,
+    };
+
+    this.planAuditoriaService.post('plan-mejoramiento-estado', body).subscribe({
+      next: () => { this.cargando = false; },
+      error: () => { this.cargando = false; }
+    });
+  }
+
+  guardar(): void {
+    this.alertService.showSuccessAlert(
+      'El plan de mejoramiento ha sido guardado.',
+      'Guardado'
+    );
+  }
+
+  enviarAuditor(): void {
+    if (!this.planMejoramientoId) return;
+
+    this.alertService.showConfirmAlert(
+      '¿Enviar el plan al auditor para revisión?'
+    ).then(conf => {
+      if (!conf.value) return;
+
+      this.enviando = true;
+      const body = {
+        plan_mejoramiento_id:   this.planMejoramientoId,
+        usuario_id:             this.usuarioId,
+        usuario_rol:            this.role,
+        observacion:            'Plan enviado a revisión del auditor',
+        estado_id:              environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR,
+        fase_id:                environment.AUDITORIA_FASE.PLAN_MEJORAMIENTO,
+        fecha_ejecucion_estado: new Date().toISOString(),
+        activo:                 true,
+      };
+
+      this.planAuditoriaService.post('plan-mejoramiento-estado', body).subscribe({
+        next: () => {
+          this.enviando = false;
+          this.alertService.showSuccessAlert(
+            'El plan fue enviado al auditor para revisión.',
+            'Enviado'
+          ).then(() => this.router.navigate(['/plan-mejoramiento']));
+        },
+        error: () => {
+          this.enviando = false;
+          this.alertService.showErrorAlert('Error al enviar el plan al auditor.');
+        }
+      });
+    });
+  }
+
   regresar(): void {
-    this.router.navigate(['/planes/plan-mejoramiento']);
+    this.router.navigate(['/plan-mejoramiento']);
   }
 }

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.html
@@ -41,13 +41,13 @@
       <!-- Tipo de Acción -->
       <ng-container matColumnDef="tipoAccion">
         <th mat-header-cell *matHeaderCellDef><b>Tipo de Acción</b></th>
-        <td mat-cell *matCellDef="let fila">{{ fila.accion?.tipoAccion ?? 'Sin Tipo' }}</td>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.tipoAccion }}</td>
       </ng-container>
 
       <!-- Acción Planteada -->
       <ng-container matColumnDef="accionPlanteada">
         <th mat-header-cell *matHeaderCellDef><b>Acción Planteada</b></th>
-        <td mat-cell *matCellDef="let fila">{{ fila.accion?.accionPlanteada ?? 'Sin Acción' }}</td>
+        <td mat-cell *matCellDef="let fila">{{ fila.accion?.accionPlanteada }}</td>
       </ng-container>
 
       <!-- Nombre Indicador -->

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/tabla-hallazgos/tabla-hallazgos.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { catchError, forkJoin, of, switchMap } from 'rxjs';
 import { PlanAnualAuditoriaService } from 'src/app/core/services/plan-anual-auditoria.service';
+import { AlertService } from 'src/app/shared/services/alert.service';
 import { ModalRegistrarAccionComponent } from '../modal-registrar-accion/modal-registrar-accion.component';
 
 export interface HallazgoTabla {
@@ -16,6 +18,7 @@ export interface AccionPlan {
   accionId?: string;
   numero: string;
   tipoAccion: string;
+  tipoAccionId?: number;
   accionPlanteada: string;
   nombreIndicador: string;
   formulaIndicador: string;
@@ -25,19 +28,29 @@ export interface AccionPlan {
   fechaFin: string;
 }
 
-/**
- * Fila del datasource plano.
- * - esGrupo = true  → fila de cabecera del hallazgo (usa columna 'grupo')
- * - esGrupo = false → fila de una acción concreta (usa columnas normales)
- */
+export interface ResultadoModalAccion {
+  accion: {
+    tipoAccionId: number;
+    accionPlanteada: string;
+    nombreIndicador: string;
+    formulaIndicador: string;
+    meta: string;
+    accionId?: string;
+  };
+  responsablesNuevos: { dependencia_id: number; dependencia_lider: boolean }[];
+  responsablesAEliminar: string[];
+}
+
 export interface FilaTabla {
   esGrupo: boolean;
   hallazgoId: string;
   hallazgoIndice: string;
   hallazgoDescripcion: string;
-  hallazgoCausa: string;        // ← criterio del hallazgo (campo 'criterio' del backend)
+  hallazgoCausa: string;
   accion?: AccionPlan;
 }
+
+const TIPO_NOMBRES: Record<number, string> = { 1: 'Preventiva', 2: 'Correctiva' };
 
 @Component({
   selector: 'app-tabla-hallazgos',
@@ -46,12 +59,12 @@ export interface FilaTabla {
 })
 export class TablaHallazgosComponent implements OnInit {
   @Input() auditoriaId!: string;
+  @Input() planMejoramientoId!: string;
   @Input() auditoria: any;
 
   hallazgos: HallazgoTabla[] = [];
   filas: FilaTabla[] = [];
   cargando = true;
-  informeId!: string;
 
   columnas = [
     'noHallazgo', 'descripcion', 'causa', 'numero', 'tipoAccion',
@@ -64,11 +77,12 @@ export class TablaHallazgosComponent implements OnInit {
 
   constructor(
     private readonly planAuditoriaService: PlanAnualAuditoriaService,
+    private readonly alertService: AlertService,
     private readonly dialog: MatDialog,
   ) {}
 
   ngOnInit(): void {
-    this.cargarHallazgos();
+    this.cargarDatos();
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -81,7 +95,6 @@ export class TablaHallazgosComponent implements OnInit {
     const filas: FilaTabla[] = [];
 
     this.hallazgos.forEach(h => {
-      // Fila de cabecera del hallazgo (siempre visible)
       filas.push({
         esGrupo:             true,
         hallazgoId:          h.hallazgoId,
@@ -90,95 +103,90 @@ export class TablaHallazgosComponent implements OnInit {
         hallazgoCausa:       h.causa,
       });
 
-      if (h.expandido) {
-        if (h.acciones.length > 0) {
-          h.acciones.forEach(accion => {
-            filas.push({
-              esGrupo:             false,
-              hallazgoId:          h.hallazgoId,
-              hallazgoIndice:      h.indice,
-              hallazgoDescripcion: h.descripcion,
-              hallazgoCausa:       h.causa,
-              accion,
-            });
-          });
-        } else {
-          // Fila placeholder cuando no hay acciones
+      if (h.expandido && h.acciones.length > 0) {
+        h.acciones.forEach(accion => {
           filas.push({
             esGrupo:             false,
             hallazgoId:          h.hallazgoId,
             hallazgoIndice:      h.indice,
             hallazgoDescripcion: h.descripcion,
             hallazgoCausa:       h.causa,
-            accion:              undefined,
+            accion,
           });
-        }
+        });
       }
     });
 
     this.filas = filas;
   }
 
+  private mapearAccion(a: any, index: number): AccionPlan {
+    return {
+      accionId:         a._id,
+      numero:           String(index + 1),
+      tipoAccionId:     a.tipo_id ?? 1,
+      tipoAccion:       TIPO_NOMBRES[a.tipo_id] ?? '',
+      accionPlanteada:  a.descripcion ?? '',
+      nombreIndicador:  a.nombre_indicador ?? '',
+      formulaIndicador: a.formula_indicador ?? '',
+      meta:             a.meta ?? '',
+      responsable:      '',
+      fechaInicio:      a.fecha_inicio ?? '',
+      fechaFin:         a.fecha_fin ?? '',
+    };
+  }
+
   // ─── Carga de datos ──────────────────────────────────────────────────────────
 
-  cargarHallazgos(): void {
-    const estadoPrevio = new Map<string, { expandido: boolean; acciones: AccionPlan[] }>();
-    this.hallazgos.forEach(h => estadoPrevio.set(h.hallazgoId, {
-      expandido: h.expandido,
-      acciones:  h.acciones,
-    }));
+  cargarDatos(): void {
+    this.cargando = true;
+    const estadoPrevio = new Map<string, boolean>();
+    this.hallazgos.forEach(h => estadoPrevio.set(h.hallazgoId, h.expandido));
 
     this.planAuditoriaService
       .get(`informe?query=auditoria_id:${this.auditoriaId},activo:true`)
+      .pipe(
+        switchMap((resInforme) => {
+          if (!resInforme.Data?.length) {
+            return of({ hallazgos: { Data: [] }, acciones: { Data: [] } });
+          }
+          const informeId = resInforme.Data[0]._id;
+          return forkJoin({
+            hallazgos: this.planAuditoriaService
+              .get(`hallazgo?query=informe_id:${informeId},activo:true`),
+            acciones: this.planAuditoriaService
+              .get(`accion-mejora?query=plan_mejoramiento_id:${this.planMejoramientoId},activo:true`)
+              .pipe(catchError(() => of({ Data: [] }))),
+          });
+        })
+      )
       .subscribe({
-        next: (res) => {
-          if (!res.Data?.length) { this.cargando = false; return; }
-          this.informeId = res.Data[0]._id;
-          this.cargarHallazgosDeInforme(estadoPrevio);
-        },
-        error: () => { this.cargando = false; }
-      });
-  }
-
-  private cargarHallazgosDeInforme(
-    estadoPrevio: Map<string, { expandido: boolean; acciones: AccionPlan[] }>
-  ): void {
-    this.planAuditoriaService
-      .get(`tema?query=informe_id:${this.informeId}`)
-      .subscribe({
-        next: (res) => {
-          const temas: any[] = res.Data ?? [];
-          const hallazgosList: HallazgoTabla[] = [];
-          let temaCount = 0;
-
-          temas.forEach((tema: any) => {
-            if (!tema.activo) return;
-            temaCount++;
-            let subtemaCount = 0;
-
-            (tema.subtema ?? []).forEach((subtema: any) => {
-              if (!subtema.activo) return;
-              subtemaCount++;
-              let hallazgoCount = 0;
-
-              (subtema.hallazgo ?? []).forEach((hallazgo: any) => {
-                if (!hallazgo.activo) return;
-                hallazgoCount++;
-
-                const previo = estadoPrevio.get(hallazgo._id);
-                hallazgosList.push({
-                  hallazgoId:  hallazgo._id,
-                  indice:      `${temaCount}.${subtemaCount}.${hallazgoCount}`,
-                  descripcion: hallazgo.descripcion ?? hallazgo.titulo ?? '',
-                  causa:       hallazgo.criterio   ?? '',   // ← campo correcto del backend
-                  acciones:    previo?.acciones  ?? [],
-                  expandido:   previo?.expandido ?? false,
-                });
-              });
-            });
+        next: ({ hallazgos, acciones }) => {
+          const accionesData: any[] = acciones.Data ?? [];
+          const accionesPorHallazgo = new Map<string, any[]>();
+          accionesData.forEach((a: any) => {
+            // hallazgo_id puede venir como string o como objeto populado { _id, ... }
+            const key = typeof a.hallazgo_id === 'object'
+              ? a.hallazgo_id?._id
+              : a.hallazgo_id;
+            if (!key) return;
+            const lista = accionesPorHallazgo.get(key) ?? [];
+            lista.push(a);
+            accionesPorHallazgo.set(key, lista);
           });
 
-          this.hallazgos = hallazgosList;
+          this.hallazgos = (hallazgos.Data ?? [])
+            .filter((h: any) => h.activo !== false)
+            .map((h: any, i: number) => ({
+              hallazgoId:  h._id,
+              indice:      String(i + 1),
+              descripcion: h.descripcion ?? h.titulo ?? '',
+              causa:       h.criterio ?? '',
+              expandido:   estadoPrevio.get(h._id) ?? false,
+              acciones:    (accionesPorHallazgo.get(h._id) ?? [])
+                             .map((a: any, j: number) => this.mapearAccion(a, j)),
+            }));
+
           this.reconstruirFilas();
           this.cargando = false;
         },
@@ -206,34 +214,125 @@ export class TablaHallazgosComponent implements OnInit {
         hallazgo,
         accion: accion ?? null,
         auditoria: this.auditoria,
+        planMejoramientoId: this.planMejoramientoId,
       },
     });
 
-    dialogRef.afterClosed().subscribe((resultado: AccionPlan | null) => {
+    dialogRef.afterClosed().subscribe((resultado: ResultadoModalAccion | null) => {
       if (!resultado) return;
-
-      if (accion) {
-        const idx = hallazgo.acciones.indexOf(accion);
-        if (idx !== -1) hallazgo.acciones[idx] = resultado;
-      } else {
-        hallazgo.acciones.push({
-          ...resultado,
-          numero: String(hallazgo.acciones.length + 1),
-        });
-      }
-
-      hallazgo.expandido = true;
-      this.reconstruirFilas();
+      accion ? this.actualizarAccion(resultado, accion) : this.crearAccion(resultado, hallazgo);
     });
   }
 
-  // ─── Eliminar (mock local) ───────────────────────────────────────────────────
+  // ─── Persistencia ────────────────────────────────────────────────────────────
+
+  private crearAccion(resultado: ResultadoModalAccion, hallazgo: HallazgoTabla): void {
+    const body = {
+      plan_mejoramiento_id: this.planMejoramientoId,
+      hallazgo_id:          hallazgo.hallazgoId,
+      descripcion:          resultado.accion.accionPlanteada,
+      tipo_id:              resultado.accion.tipoAccionId,
+      nombre_indicador:     resultado.accion.nombreIndicador,
+      formula_indicador:    resultado.accion.formulaIndicador,
+      meta:                 resultado.accion.meta,
+      activo:               true,
+    };
+
+    this.planAuditoriaService.post('accion-mejora', body).subscribe({
+      next: (res: any) => {
+        const accionId = res.Data._id;
+        this.guardarResponsables(accionId, resultado.responsablesNuevos, () => {
+          hallazgo.expandido = true;
+          this.cargarDatos();
+        });
+      },
+      error: () => this.alertService.showErrorAlert('Error al guardar la acción de mejora.'),
+    });
+  }
+
+  private actualizarAccion(resultado: ResultadoModalAccion, accionAnterior: AccionPlan): void {
+    const body = {
+      descripcion:       resultado.accion.accionPlanteada,
+      tipo_id:           resultado.accion.tipoAccionId,
+      nombre_indicador:  resultado.accion.nombreIndicador,
+      formula_indicador: resultado.accion.formulaIndicador,
+      meta:              resultado.accion.meta,
+    };
+
+    this.planAuditoriaService
+      .put(`accion-mejora/${accionAnterior.accionId}`, body as any)
+      .subscribe({
+        next: () => {
+          this.sincronizarResponsables(
+            accionAnterior.accionId!,
+            resultado.responsablesNuevos,
+            resultado.responsablesAEliminar,
+            () => this.cargarDatos()
+          );
+        },
+        error: () => this.alertService.showErrorAlert('Error al actualizar la acción de mejora.'),
+      });
+  }
 
   eliminarAccion(hallazgo: HallazgoTabla | undefined, accion: AccionPlan | undefined): void {
-    if (!hallazgo || !accion) return;
-    hallazgo.acciones = hallazgo.acciones
-      .filter(a => a !== accion)
-      .map((a, i) => ({ ...a, numero: String(i + 1) }));
-    this.reconstruirFilas();
+    if (!hallazgo || !accion?.accionId) return;
+
+    this.alertService.showConfirmAlert('¿Eliminar esta acción de mejora?').then(conf => {
+      if (!conf.value) return;
+
+      this.planAuditoriaService.delete('accion-mejora', { id: accion.accionId }).subscribe({
+        next: () => this.cargarDatos(),
+        error: () => this.alertService.showErrorAlert('Error al eliminar la acción.'),
+      });
+    });
+  }
+
+  // ─── Responsables ────────────────────────────────────────────────────────────
+
+  private guardarResponsables(
+    accionId: string,
+    responsables: { dependencia_id: number; dependencia_lider: boolean }[],
+    callback: () => void
+  ): void {
+    if (!responsables.length) { callback(); return; }
+
+    // catchError individual: un fallo no cancela el resto del forkJoin
+    const requests = responsables.map(r =>
+      this.planAuditoriaService.post('responsable-accion', {
+        accion_mejora_id:  accionId,
+        dependencia_id:    r.dependencia_id,
+        dependencia_lider: r.dependencia_lider,
+        activo:            true,
+      }).pipe(catchError(err => { console.error('Error responsable:', err); return of(null); }))
+    );
+
+    forkJoin(requests).subscribe({ next: () => callback(), error: () => callback() });
+  }
+
+  private sincronizarResponsables(
+    accionId: string,
+    nuevos: { dependencia_id: number; dependencia_lider: boolean }[],
+    aEliminar: string[],
+    callback: () => void
+  ): void {
+    const creaciones = nuevos.map(r =>
+      this.planAuditoriaService.post('responsable-accion', {
+        accion_mejora_id:  accionId,
+        dependencia_id:    r.dependencia_id,
+        dependencia_lider: r.dependencia_lider,
+        activo:            true,
+      }).pipe(catchError(err => { console.error('Error responsable:', err); return of(null); }))
+    );
+
+    const eliminaciones = aEliminar.map(id =>
+      this.planAuditoriaService
+        .delete('responsable-accion', { id })
+        .pipe(catchError(err => { console.error('Error eliminar responsable:', err); return of(null); }))
+    );
+
+    const todas = [...creaciones, ...eliminaciones];
+    if (!todas.length) { callback(); return; }
+
+    forkJoin(todas).subscribe({ next: () => callback(), error: () => callback() });
   }
 }

--- a/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
+++ b/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
@@ -6,11 +6,11 @@ import { RegistrarPlanComponent } from './components/plan-de-mejoramiento/ tabla
 const routes: Routes = [
   {
     path: '',
-    component: PlanDeMejoramientoComponent,
+    component: PlanDeMejoramientoComponent,   
   },
   {
     path: 'registrar-plan/:id',
-    component: RegistrarPlanComponent,
+    component: RegistrarPlanComponent,      
   },
 ];
 

--- a/src/app/shared/data/models/plan-mejoramiento/plan-mejoramiento.models.ts
+++ b/src/app/shared/data/models/plan-mejoramiento/plan-mejoramiento.models.ts
@@ -1,0 +1,93 @@
+export interface PlanMejoramiento {
+  _id: string;
+  auditoria_id: string;
+  vigencia_id: number;
+  tipo_evaluacion_id: number;
+  fecha_apertura: string;
+  fecha_limite: string;
+  estado_id: number;
+  fuente: number;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}
+
+export interface PlanMejoramientoAuditor {
+  _id: string;
+  plan_mejoramiento_id: string;
+  auditor_id: number;
+  asignado: boolean;
+  asignado_por_id: number;
+  auditor_lider: boolean;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}
+
+export interface PlanMejoramientoEstado {
+  _id: string;
+  plan_mejoramiento_id: string;
+  usuario_id: number;
+  usuario_rol: string;
+  observacion: string;
+  actual: boolean;
+  estado_id: number;
+  fase_id: string;
+  fecha_ejecucion_estado: string;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}
+
+export interface AccionMejora {
+  _id: string;
+  plan_mejoramiento_id: string;
+  hallazgo_id: string;
+  descripcion: string;
+  tipo: string;
+  nombre_indicador: string;
+  formula_indicador: string;
+  meta: string;
+  comentario_auditor: string;
+  estado_id: number;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}
+
+export interface AccionMejoraResponsable {
+  _id: string;
+  accion_mejora_id: string;
+  dependencia_id: number;
+  lider_id: number;
+  tipo_responsable: string;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}
+
+export interface SeguimientoAccion {
+  _id: string;
+  accion_mejora_id: string;
+  plan_mejoramiento_id: string;
+  usuario_id: number;
+  usuario_rol: string;
+  descripcion_avance: string;
+  porcentaje_avance: number;
+  fecha_avance: string;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}
+
+export interface EficaciaAccion {
+  _id: string;
+  accion_mejora_id: string;
+  auditor_id: number;
+  calificacion: number;
+  observacion: string;
+  fecha_calificacion: string;
+  activo: boolean;
+  fecha_creacion: string;
+  fecha_modificacion: string;
+}

--- a/src/app/shared/utils/accionesPorRolYEstado.ts
+++ b/src/app/shared/utils/accionesPorRolYEstado.ts
@@ -625,3 +625,157 @@ export const accionesEjecucionFinal: {
     ],
   },
 };
+
+export const accionesPlanMejoramiento: {
+  [rol: string]: { [estado: number]: string[] };
+} = {
+  [environment.ROL.JEFE]: {
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.SIN_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Aprobar Plan",
+      "Rechazar Plan",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.APROBADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.RECHAZADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.FIN_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+  },
+
+  [environment.ROL.AUDITOR_EXPERTO]: {
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.SIN_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Aprobar Plan",
+      "Rechazar Plan",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.APROBADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.RECHAZADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.FIN_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+  },
+
+  [environment.ROL.AUDITOR]: {
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.SIN_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Aprobar Plan",
+      "Rechazar Plan",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.APROBADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.RECHAZADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.FIN_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+  },
+
+  [environment.ROL.AUDITOR_ASISTENTE]: {
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.SIN_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.APROBADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.RECHAZADO_PLAN_MEJORAMIENTO]: [
+      "Asignar Auditor(es)",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.FIN_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+  },
+
+  [environment.ROL.JEFE_DEPENDENCIA]: {
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Enviar a Revisión",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR]: [
+      "Registrar Plan",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.APROBADO_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.RECHAZADO_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Enviar a Revisión",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.FIN_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+  },
+
+  [environment.ROL.ASISTENTE_DEPENDENCIA]: {
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.CREANDO_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Enviar a Revisión",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.REVISION_PLAN_MEJORAMIENTO_AUDITOR]: [
+      "Registrar Plan",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.APROBADO_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.RECHAZADO_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Enviar a Revisión",
+    ],
+    [environment.AUDITORIA_ESTADO.PLAN_MEJORAMIENTO.FIN_PLAN_MEJORAMIENTO]: [
+      "Registrar Plan",
+      "Ver Documentos Auditoría",
+    ],
+  },
+};

--- a/src/app/shared/utils/dias-habiles.util.ts
+++ b/src/app/shared/utils/dias-habiles.util.ts
@@ -1,0 +1,25 @@
+import Holidays from 'date-holidays';
+
+const hd = new Holidays('CO');
+
+/** Devuelve true si la fecha es día hábil (no fin de semana ni festivo colombiano). */
+export function esDiaHabil(fecha: Date): boolean {
+  const dia = fecha.getDay();
+  if (dia === 0 || dia === 6) return false;
+  return !hd.isHoliday(fecha);
+}
+
+/**
+ * Suma N días hábiles a una fecha base, excluyendo fines de semana
+ * y festivos nacionales colombianos según date-holidays.
+ * Usada para calcular fecha_limite de plan_mejoramiento (+8 días hábiles).
+ */
+export function sumarDiasHabiles(fechaBase: Date, dias: number): Date {
+  const resultado = new Date(fechaBase);
+  let contados = 0;
+  while (contados < dias) {
+    resultado.setDate(resultado.getDate() + 1);
+    if (esDiaHabil(resultado)) contados++;
+  }
+  return resultado;
+}


### PR DESCRIPTION
## Integración Formulario Plan de Mejoramiento con CRUD

Continúa el trabajo iniciado en #668. Esta PR conecta el módulo de plan de mejoramiento al backend CRUD de extremo a extremo: desde la creación automática del plan hasta el envío al auditor, incluyendo la gestión completa de hallazgos, acciones y responsables.

---

### Cambios por subtarea

#### 1. Modelos, utilidad de días hábiles y acciones por rol

- Se añaden interfaces TypeScript para todas las entidades del CRUD (`PlanMejoramiento`, `AccionMejora`, `AccionMejoraResponsable`, entre otras) en `plan-mejoramiento.models.ts`.
- Nueva utilidad `sumarDiasHabiles(fechaBase, dias)` implementada con `date-holidays@3.28.0` y `new Holidays('CO')`, cubriendo los 20 festivos colombianos vigentes (fijos, Ley Emiliani y Semana Santa) sin lógica manual.
- Se extiende `accionesPorRolYEstado` con la exportación `accionesPlanMejoramiento`, cubriendo 6 roles por 5 estados del plan (7082–7086).

#### 2. Consulta y guardado del plan — `RegistrarPlanComponent`

- Al cargar la vista se ejecuta `resolverPlanMejoramiento()`: obtiene el plan existente mediante `GET /plan-mejoramiento` o lo crea vía `POST /plan-mejoramiento` con `fecha_limite` calculada a 8 días hábiles desde la fecha actual y estado inicial `7082`.
- El `planMejoramientoId` resultante se transfiere al componente hijo `app-tabla-hallazgos` por `@Input`. El `*ngIf` del template garantiza que no se realicen llamadas al backend con ID nulo.
- El botón **Guardar** presenta una alerta de éxito; la persistencia de cada acción se gestiona individualmente desde el modal.
- El botón **Enviar a Auditor** solicita confirmación al usuario y ejecuta `POST /plan-mejoramiento-estado` con estado `7083`, redirigiendo a la lista al completarse. El botón permanece deshabilitado durante el procesamiento o si el plan aún no ha sido creado.
- Se corrige bug de navegación: `regresar()` apuntaba a `/planes/plan-mejoramiento` en lugar de `/plan-mejoramiento`.

#### 3. Carga de hallazgos y acciones — `TablaHallazgosComponent`

- Se reemplaza la cadena encadenada `informe → tema → subtema → hallazgo` por un flujo `switchMap + forkJoin`: primero se obtiene el `informeId` y luego se consultan hallazgos y acciones en paralelo.
- Las acciones se cruzan con los hallazgos por `hallazgo_id` mediante un `Map` que normaliza el campo a `string`, soportando tanto el valor directo como el objeto populado.
- La llamada a `GET /accion-mejora` incluye `catchError(() => of({ Data: [] }))` para evitar que un error en ese endpoint bloquee la carga de hallazgos.
- Se corrigen los campos reales del CRUD: `tipo_id: number` en `accion-mejora` y `dependencia_lider: boolean` en `responsable-accion` (nombre real del endpoint, distinto de `accion-mejora-responsable`).
- Se implementa el CRUD completo de acciones: `crearAccion` ejecuta `POST /accion-mejora` seguido de `POST /responsable-accion × N` en `forkJoin`; `actualizarAccion` ejecuta `PUT` y sincroniza responsables (altas y bajas en paralelo); `eliminarAccion` solicita confirmación y ejecuta `DELETE`. Cada `POST /responsable-accion` individual tiene su propio `catchError` para que un fallo parcial no cancele el `forkJoin`.
- Se eliminan las filas placeholder que aparecían en hallazgos expandidos sin acciones, así como los textos de fallback innecesarios del template.

#### 4. Dependencias reales y responsables — `ModalRegistrarAccionComponent`

- Las dependencias se cargan desde `OikosService` (`dependencia?limit=0&query=Activo:true`), reemplazando el array hardcodeado de 5 elementos.
- Las dependencias disponibles en el dropdown se computan dinámicamente como la diferencia entre `todasDependencias` y `responsablesAgregados`, eliminando la necesidad de mover elementos entre arrays.
- En modo edición se restauran los responsables existentes mediante `GET /responsable-accion?query=accion_mejora_id:{id}`, filtrando por `dependencia_lider === false` para mostrar únicamente dependencias adicionales.
- Al crear una acción, la dependencia líder de la auditoría se incluye automáticamente con `dependencia_lider: true`, siempre que `auditoria.dependencia_id` sea un valor válido.
- Se corrige bug en `poblarForm()`: el campo `causa` se mapeaba incorrectamente al valor de `tipoAccion`; ahora se pre-puebla desde `hallazgo.causa` tanto en creación como en edición.

