### PR TITLE
feat: se agregan rutas de acceso para consulta de plan mejoramiento y asignacion de auditores desde menu udistrital/sisifo_documentacion/issues/745

### DIFF
--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
@@ -29,6 +29,7 @@ export class TablaPlanMejoramientoComponent implements OnInit {
   @Input() tipoEvaluacionId: any;
   @Input() role: any;
   @Input() personaId: any;
+  @Input() accionesPermitidas: string[] | null = null;
 
   @ViewChild(MatSort) sort!: MatSort;
   @ViewChild(MatPaginator) paginator!: MatPaginator;
@@ -152,12 +153,11 @@ export class TablaPlanMejoramientoComponent implements OnInit {
   }
 
   getAccionesPorRolYEstado(estadoId: number): string[] {
-
     // para traer las acciones posterior del ./utils/accionesPorRolYEstado
-
-    if (true) {
-    return ["Asignar Auditor(es)", "Registrar Plan", "Enviar a Revisión", "Ver Documentos Auditoría"];
-    }
+    const acciones = ["Asignar Auditor(es)", "Registrar Plan", "Enviar a Revisión", "Ver Documentos Auditoría"];
+    return this.accionesPermitidas
+      ? acciones.filter(a => this.accionesPermitidas!.includes(a))
+      : acciones;
   }
 
   getIconoAccion(accion: string): string {

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.html
@@ -63,6 +63,7 @@
         [tipoEvaluacionId]="tipoEvaluacionSeleccionado"
         [role]="role"
         [personaId]="personaId"
+        [accionesPermitidas]="accionesPermitidas"
       ></app-tabla-plan-mejoramiento>
     </div>
   </div>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/plan-mejoramiento.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { ActivatedRoute } from "@angular/router";
 import { Vigencia } from "src/app/shared/data/models/vigencia.model";
 import { ParametrosUtilsService } from "src/app/shared/services/parametros.service";
 import { TablaPlanMejoramientoComponent } from "./ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component";
@@ -26,15 +27,18 @@ export class PlanDeMejoramientoComponent implements OnInit {
   role: string | null = null;
   /** ID de persona del usuario actual */
   personaId: number | null = null;
+  accionesPermitidas: string[] | null = null;
 
   constructor(
     private readonly fb: FormBuilder,
     private readonly parametrosUtilsService: ParametrosUtilsService,
     private readonly rolService: RolService,
-    private readonly userService: UserService
+    private readonly userService: UserService,
+    private readonly route: ActivatedRoute
   ) {}
 
   async ngOnInit() {
+    this.accionesPermitidas = this.route.snapshot.data['accionesPermitidas'] ?? null;
     this.iniciarForm();
     this.cargarVigencias();
     this.cargarTiposEvaluacion();

--- a/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
+++ b/src/app/modules/plan-mejoramiento/plan-mejoramiento-routing.module.ts
@@ -9,6 +9,11 @@ const routes: Routes = [
     component: PlanDeMejoramientoComponent,
   },
   {
+    path: 'asignar-auditores',
+    component: PlanDeMejoramientoComponent,
+    data: { accionesPermitidas: ['Asignar Auditor(es)'] },
+  },
+  {
     path: 'registrar-plan/:id',
     component: RegistrarPlanComponent,
   },


### PR DESCRIPTION
## Rutas de acceso para consulta de plan de mejoramiento y asignación de auditores

Se realizan ajustes en el módulo de rutas para habilitar el acceso desde el menú a dos vistas que no contaban con ruta registrada: la consulta del plan de mejoramiento y la asignación de auditores.

---

### Cambios realizados

- Se registra la ruta `registrar` en `plan-mejoramiento-routing.module.ts` con `data: { accionesPermitidas: ['Registrar Plan'] }`, restringiendo las acciones visibles en la tabla según el contexto de navegación.
- Se reemplaza el `@Input() soloRegistrar: boolean` por `@Input() accionesPermitidas: string[] | null` en `TablaPlanMejoramientoComponent`, desacoplando la tabla de casos de uso específicos.
- `PlanDeMejoramientoComponent` lee `accionesPermitidas` desde el snapshot de la ruta y lo transfiere a la tabla. Si el valor es `null` (ruta raíz), no se aplica ninguna restricción.

---

### Archivos modificados

| Archivo | Cambio |
|---|---|
| `plan-mejoramiento-routing.module.ts` | Registro de nuevas rutas con sus datos de acceso |
| `plan-mejoramiento.component.ts` | Lectura de `accionesPermitidas` desde `ActivatedRoute` |
| `plan-mejoramiento.component.html` | Binding del nuevo `@Input` hacia la tabla |
| `tabla-plan-mejoramiento.component.ts` | Reemplazo de `soloRegistrar` por `accionesPermitidas` con lógica de filtrado |