### PR TITLE
feat: Permitir remplazo de documentos en planeación de internas sólo en estados del auditado

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -271,12 +271,18 @@ export class TablaAuditoriasInternasComponent implements OnInit {
       });
   }
 
-  puedeRemplazarDocumento(rol: string): boolean {
-    return [
+  puedeRemplazarDocumento(rol: string, estado_id: number): boolean {
+    const esAuditor = [
         environment.ROL.AUDITOR_EXPERTO,
         environment.ROL.AUDITOR,
         environment.ROL.AUDITOR_ASISTENTE
       ].includes(rol);
+    const esEstadoAuditado = [
+        environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO,
+        environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_AUDITADO
+      ].includes(estado_id);
+
+    return esAuditor && esEstadoAuditado;
   }
 
   private esUsuarioAuditado(): boolean {
@@ -329,7 +335,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
   async verDocumentos(auditoria: Auditoria) {
     const auditoriaId = auditoria._id;
     const getAdjuntoConfigByRole = (rol: string): CargueAdjuntoTabConfig | undefined => {
-      if (!this.puedeRemplazarDocumento(rol))
+      if (!this.puedeRemplazarDocumento(rol, auditoria.estado_id))
         return undefined;
 
       return {


### PR DESCRIPTION
This pull request updates the logic for determining whether a user can replace a document in the `TablaAuditoriasInternasComponent`. The main change is that now, in addition to checking the user's role, the component also checks the audit's state before allowing document replacement.

-  udistrital/sisifo_documentacion#783

**Permission logic improvements:**

* The `puedeRemplazarDocumento` method now requires both the user's role and the audit's `estado_id` to allow document replacement, ensuring only auditors in specific audit states can replace documents. Current implementation allows only states in which the auditee controls the state flow.
* The call to `puedeRemplazarDocumento` in the `verDocumentos` method is updated to pass the audit's `estado_id`, aligning the usage with the new method signature.