### PR TITLE
feat: Cambiar color de carga y descarga de carta de representación

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -307,6 +307,9 @@ export class RevisionDocumentosComponent implements OnInit {
           documentoId: documento._id,
           botones: [{
             nombre: "Descargar Carta",
+            color: "primary",
+            estilo: "border: 1px solid var(--md-primary-500);",
+            tipo: "stroked",
             accion: async () => {
               const base64 = await this.nuxeoService.obtenerPorUUID(documento.nuxeo_enlace);
               this.descargaService.descargarArchivo(
@@ -317,7 +320,9 @@ export class RevisionDocumentosComponent implements OnInit {
           cargueAdjuntoConfig: {
             nombreBoton: "Cargar Carta Firmada",
             iconoBoton: "upload_file",
-            colorBoton: "accent",
+            colorBoton: "primary",
+            tipoBoton: "stroked",
+            estiloBoton: "border: 1px solid var(--md-primary-500);",
             idTipoDocumento: environment.TIPO_DOCUMENTO.PROGRAMA_TRABAJO_AUDITORIA,
             descripcion: `Carta de representación firmada - ${dependenciaNombre}`,
             referenciaTipoFallback: "Auditoria",

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.html
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.html
@@ -11,25 +11,95 @@
             Descargar Todo <mat-icon>insert_drive_file</mat-icon>
         </button>
         <ng-container *ngIf="tabs && tabs[selectedTab] && tabs[selectedTab].botones">
+            <ng-container *ngFor="let boton of tabs[selectedTab].botones" [ngSwitch]="boton.tipo || 'flat'">
+                <button
+                    *ngSwitchCase="'flat'"
+                    class="modal-btn"
+                    mat-flat-button
+                    [color]="boton.color || 'accent'"
+                    [style]="boton.estilo || ''"
+                    (click)="ejecutarBotonTab(boton)"
+                >
+                    {{ boton.nombre }} <mat-icon *ngIf="boton.icono">{{ boton.icono }}</mat-icon>
+                </button>
+                <button
+                    *ngSwitchCase="'stroked'"
+                    class="modal-btn"
+                    mat-stroked-button
+                    [color]="boton.color || 'accent'"
+                    [style]="boton.estilo || ''"
+                    (click)="ejecutarBotonTab(boton)"
+                >
+                    {{ boton.nombre }} <mat-icon *ngIf="boton.icono">{{ boton.icono }}</mat-icon>
+                </button>
+                <button
+                    *ngSwitchCase="'raised'"
+                    class="modal-btn"
+                    mat-raised-button
+                    [color]="boton.color || 'accent'"
+                    [style]="boton.estilo || ''"
+                    (click)="ejecutarBotonTab(boton)"
+                >
+                    {{ boton.nombre }} <mat-icon *ngIf="boton.icono">{{ boton.icono }}</mat-icon>
+                </button>
+                <button
+                    *ngSwitchCase="'basic'"
+                    class="modal-btn"
+                    mat-button
+                    [color]="boton.color || 'accent'"
+                    [style]="boton.estilo || ''"
+                    (click)="ejecutarBotonTab(boton)"
+                >
+                    {{ boton.nombre }} <mat-icon *ngIf="boton.icono">{{ boton.icono }}</mat-icon>
+                </button>
+            </ng-container>
+        </ng-container>
+        <ng-container *ngIf="tabs && tabs[selectedTab] && tabs[selectedTab].cargueAdjuntoConfig" [ngSwitch]="tabs[selectedTab].cargueAdjuntoConfig?.tipoBoton || 'flat'">
             <button
+                *ngSwitchCase="'flat'"
                 class="modal-btn"
-                *ngFor="let boton of tabs[selectedTab].botones"
-                mat-flat-button [color]="boton.color || 'accent'"
-                (click)="ejecutarBotonTab(boton)"
+                mat-flat-button
+                [color]="tabs[selectedTab].cargueAdjuntoConfig?.colorBoton || 'accent'"
+                [style]="tabs[selectedTab].cargueAdjuntoConfig?.estiloBoton || ''"
+                (click)="abrirCargueAdjuntoTabActual()"
             >
-                {{ boton.nombre }} <mat-icon *ngIf="boton.icono">{{ boton.icono }}</mat-icon>
+                {{ tabs[selectedTab].cargueAdjuntoConfig?.nombreBoton || 'Cargar adjunto' }}
+                <mat-icon>{{ tabs[selectedTab].cargueAdjuntoConfig?.iconoBoton || 'upload_file' }}</mat-icon>
+            </button>
+            <button
+                *ngSwitchCase="'stroked'"
+                class="modal-btn"
+                mat-stroked-button
+                [color]="tabs[selectedTab].cargueAdjuntoConfig?.colorBoton || 'accent'"
+                [style]="tabs[selectedTab].cargueAdjuntoConfig?.estiloBoton || ''"
+                (click)="abrirCargueAdjuntoTabActual()"
+            >
+                {{ tabs[selectedTab].cargueAdjuntoConfig?.nombreBoton || 'Cargar adjunto' }}
+                <mat-icon>{{ tabs[selectedTab].cargueAdjuntoConfig?.iconoBoton || 'upload_file' }}</mat-icon>
+            </button>
+            <button
+                *ngSwitchCase="'raised'"
+                class="modal-btn"
+                mat-raised-button
+                [color]="tabs[selectedTab].cargueAdjuntoConfig?.colorBoton || 'accent'"
+                [style]="tabs[selectedTab].cargueAdjuntoConfig?.estiloBoton || ''"
+                (click)="abrirCargueAdjuntoTabActual()"
+            >
+                {{ tabs[selectedTab].cargueAdjuntoConfig?.nombreBoton || 'Cargar adjunto' }}
+                <mat-icon>{{ tabs[selectedTab].cargueAdjuntoConfig?.iconoBoton || 'upload_file' }}</mat-icon>
+            </button>
+            <button
+                *ngSwitchCase="'basic'"
+                class="modal-btn"
+                mat-button
+                [color]="tabs[selectedTab].cargueAdjuntoConfig?.colorBoton || 'accent'"
+                [style]="tabs[selectedTab].cargueAdjuntoConfig?.estiloBoton || ''"
+                (click)="abrirCargueAdjuntoTabActual()"
+            >
+                {{ tabs[selectedTab].cargueAdjuntoConfig?.nombreBoton || 'Cargar adjunto' }}
+                <mat-icon>{{ tabs[selectedTab].cargueAdjuntoConfig?.iconoBoton || 'upload_file' }}</mat-icon>
             </button>
         </ng-container>
-        <button
-            class="modal-btn"
-            *ngIf="tabs && tabs[selectedTab] && tabs[selectedTab].cargueAdjuntoConfig"
-            mat-flat-button
-            [color]="tabs[selectedTab].cargueAdjuntoConfig?.colorBoton || 'accent'"
-            (click)="abrirCargueAdjuntoTabActual()"
-        >
-            {{ tabs[selectedTab].cargueAdjuntoConfig?.nombreBoton || 'Cargar adjunto' }}
-            <mat-icon>{{ tabs[selectedTab].cargueAdjuntoConfig?.iconoBoton || 'upload_file' }}</mat-icon>
-        </button>
     </div>
     <div class="row">
         <div class="col-sm-12 col-md-4 col-lg-3 d-flex flex-column">
@@ -49,15 +119,44 @@
     </div>
 </ng-template>
 <ng-template #footerDeModal>
-    <button
-        *ngFor="let accionFooter of accionesFooter"
-        mat-flat-button
-        [color]="accionFooter.color || 'primary'"
-        class="my-3 mx-2"
-        (click)="ejecutarAccionFooter(accionFooter)"
-    >
-        <mat-icon *ngIf="accionFooter.icono">{{ accionFooter.icono }}</mat-icon>{{ accionFooter.nombre }}
-    </button>
+    <ng-container *ngFor="let accionFooter of accionesFooter" [ngSwitch]="accionFooter.tipoBoton || 'flat'">
+        <button
+            *ngSwitchCase="'flat'"
+            mat-flat-button
+            [color]="accionFooter.color || 'primary'"
+            class="my-3 mx-2"
+            (click)="ejecutarAccionFooter(accionFooter)"
+        >
+            <mat-icon *ngIf="accionFooter.icono">{{ accionFooter.icono }}</mat-icon>{{ accionFooter.nombre }}
+        </button>
+        <button
+            *ngSwitchCase="'stroked'"
+            mat-stroked-button
+            [color]="accionFooter.color || 'primary'"
+            class="my-3 mx-2"
+            (click)="ejecutarAccionFooter(accionFooter)"
+        >
+            <mat-icon *ngIf="accionFooter.icono">{{ accionFooter.icono }}</mat-icon>{{ accionFooter.nombre }}
+        </button>
+        <button
+            *ngSwitchCase="'raised'"
+            mat-raised-button
+            [color]="accionFooter.color || 'primary'"
+            class="my-3 mx-2"
+            (click)="ejecutarAccionFooter(accionFooter)"
+        >
+            <mat-icon *ngIf="accionFooter.icono">{{ accionFooter.icono }}</mat-icon>{{ accionFooter.nombre }}
+        </button>
+        <button
+            *ngSwitchCase="'basic'"
+            mat-button
+            [color]="accionFooter.color || 'primary'"
+            class="my-3 mx-2"
+            (click)="ejecutarAccionFooter(accionFooter)"
+        >
+            <mat-icon *ngIf="accionFooter.icono">{{ accionFooter.icono }}</mat-icon>{{ accionFooter.nombre }}
+        </button>
+    </ng-container>
     <button mat-stroked-button color="primary" style="border: 1px solid var(--md-primary-500)" [mat-dialog-close]
         class="my-3">
         <mat-icon>toll</mat-icon>{{ textoBotonCerrar }}

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
@@ -26,12 +26,16 @@ export interface BotonTabDocumento {
   accion: (context?: BotonTabDocumentoContext) => void | Promise<void>;
   color?: string;
   icono?: string;
+  estilo?: string;
+  tipo?: 'flat' | 'stroked' | 'raised' | 'basic'; // Tipo de botón
 }
 
 export interface CargueAdjuntoTabConfig {
   nombreBoton?: string;
   iconoBoton?: string;
   colorBoton?: string;
+  estiloBoton?: string;
+  tipoBoton?: 'flat' | 'stroked' | 'raised' | 'basic'; // Tipo de botón
   tipoArchivo?: "pdf" | "xlsx";
   idTipoDocumento: number;
   descripcion: string;
@@ -67,6 +71,7 @@ export interface AccionFooterModal {
   nombre: string;
   icono?: string;
   color?: string;
+  tipoBoton?: 'flat' | 'stroked' | 'raised' | 'basic'; // Tipo de botón
   accion: () => boolean | Promise<boolean>;
 }
 


### PR DESCRIPTION
This pull request enhances the flexibility and consistency of button rendering in the document modal and related components. It introduces support for multiple button styles (flat, stroked, raised, basic) across different UI actions, allowing for more customizable and visually consistent user interfaces. The changes affect both the UI templates and the TypeScript interfaces that define button configurations.

- udistrital/sisifo_documentacion#782

**UI Enhancements and Button Rendering:**

* Updated `modal-ver-documentos.component.html` to support rendering buttons in four different styles (`flat`, `stroked`, `raised`, `basic`) for tab actions, file upload actions, and footer actions using Angular's `ngSwitch`. This allows for more flexible and visually distinct buttons throughout the modal. [[1]](diffhunk://#diff-55eda78587f0b6f9da89450d917032ea4b7cd0cb37bac6a92c6a77191298131bR14-R102) [[2]](diffhunk://#diff-55eda78587f0b6f9da89450d917032ea4b7cd0cb37bac6a92c6a77191298131bR122-R159)

**TypeScript Interface Extensions:**

* Extended the `BotonTabDocumento`, `CargueAdjuntoTabConfig`, and `AccionFooterModal` interfaces to include new properties for button style (`tipo`, `tipoBoton`) and custom CSS (`estilo`, `estiloBoton`), enabling the new button rendering logic in the UI. [[1]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bR29-R38) [[2]](diffhunk://#diff-691ce97586a54d1bcf89becc4d1d482e8a6b268db015e9763f53c6c3c6e5bd4bR74)

**Component Configuration Updates:**

* Updated `RevisionDocumentosComponent` to specify the new button style and custom border styling for both the "Descargar Carta" action and the "Cargar Carta Firmada" file upload button, ensuring these actions use the new `stroked` style and primary color for improved visual consistency. [[1]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acR310-R312) [[2]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acL320-R325)