### PR TITLE
feat: implementación de flag de habilitación y deshabilitación para envío de notificaciones

### DIFF
--- a/src/app/shared/services/notificaciones.service.ts
+++ b/src/app/shared/services/notificaciones.service.ts
@@ -115,8 +115,9 @@ export class NotificacionesService {
 
   constructor(private notificacionesMidService: NotificacionesMidService) {}
 
+  private readonly notificacionesHabilitadas: boolean = environment['NOTIFICACIONES_HABILITADAS'] ?? true;
   /** Sender email address used for notifications */
-  private remitenteEmail = environment['ORIGEN_CORREO_NOTIFICACIONES'];
+  private readonly remitenteEmail: string = environment['ORIGEN_CORREO_NOTIFICACIONES'];
 
   /**
    * Send a notification email for a request using the NOTIFICACIONES_MID_SERVICE.
@@ -128,6 +129,7 @@ export class NotificacionesService {
     destinatarios: DestinatariosEmail,
     variables: VariablesSolicitud
   ): Observable<any> {
+    if (!this.notificacionesHabilitadas) return new Observable(o => o.complete());
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_SOLICITUD_NOMBRE,
@@ -152,6 +154,7 @@ export class NotificacionesService {
     destinatarios: DestinatariosEmail,
     variables: VariablesRechazo
   ): Observable<any> {
+    if (!this.notificacionesHabilitadas) return new Observable(o => o.complete());
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_RECHAZO_NOMBRE,
@@ -176,6 +179,7 @@ export class NotificacionesService {
     destinatarios: DestinatariosEmail,
     variables: VariablesCartaRepresentacion
   ): Observable<any> {
+    if (!this.notificacionesHabilitadas) return new Observable(o => o.complete());
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_CARTA_REPRESENTACION_NOMBRE,

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -5,6 +5,7 @@ export const environment = {
     "https://autenticacion.portaloas.udistrital.edu.co/apioas/autenticacion_mid/v1/",
   NOTIFICACIONES_MID_SERVICE:
     "https://autenticacion.portaloas.udistrital.edu.co/apioas/notificacion_mid/v1/",
+  NOTIFICACIONES_HABILITADAS: false,
   ORIGEN_CORREO_NOTIFICACIONES:
     "sisifonotificaciones@udistrital.edu.co",
   GESTOR_DOCUMENTAL_SERVICE:

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -5,6 +5,7 @@ export const environment = {
     "https://autenticacion.portaloas.udistrital.edu.co/apioas/autenticacion_mid/v1/",
   NOTIFICACIONES_MID_SERVICE:
     "https://autenticacion.portaloas.udistrital.edu.co/apioas/notificacion_mid/v1/",
+  NOTIFICACIONES_HABILITADAS: false,
   ORIGEN_CORREO_NOTIFICACIONES:
     "sisifonotificaciones@udistrital.edu.co",
   GESTOR_DOCUMENTAL_SERVICE:

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,6 +5,7 @@ export const environment = {
     "https://autenticacion.portaloas.udistrital.edu.co/apioas/autenticacion_mid/v1/",
   NOTIFICACIONES_MID_SERVICE:
     "https://autenticacion.portaloas.udistrital.edu.co/apioas/notificacion_mid/v1/",
+  NOTIFICACIONES_HABILITADAS: false,
   ORIGEN_CORREO_NOTIFICACIONES:
     "sisifonotificaciones@udistrital.edu.co",
   GESTOR_DOCUMENTAL_SERVICE:


### PR DESCRIPTION
## Control de Envío de Notificaciones

Se implementó un mecanismo de control para habilitar o deshabilitar el envío de correos electrónicos desde el frontend mediante variables de entorno.

###  Cambios realizados:
* **Configuración:** Adición del flag `NOTIFICACIONES_HABILITADAS` en el `environment`.
* **Lógica de Servicio:** Se integró un *guard* al inicio de los métodos de envío que intercepta la ejecución si las notificaciones están desactivadas.
* **Manejo de Observables:** En estado desactivado, el servicio retorna `new Observable(o => o.complete())` para asegurar la compatibilidad con los componentes suscriptores y evitar errores de `undefined`.
