### PR TITLE
feat: Se elimina consume del endpoint plantilla/plan-trabajo

### DIFF
--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
@@ -291,34 +291,6 @@ export class TablaSeguimientoComponent implements OnInit {
     acciones[accion]?.();
   }
 
-  verDocumento(auditoria: Auditoria) {
-    const auditoriaId = auditoria._id;
-    this.planAuditoriaMid
-      .get(`plantilla/plan-trabajo/${auditoriaId}`)
-      .subscribe((res) => {
-        const documentoBase64 = res.Data;
-        const dialogRef = this.dialog.open(ModalVerDocumentoComponent, {
-          width: "1000px",
-          data: documentoBase64,
-          autoFocus: false,
-        });
-
-        const modalInstance = dialogRef.componentInstance;
-        modalInstance.botonGuardar = {
-          icono: "save",
-          texto: "Guardar documento",
-        };
-
-        dialogRef.afterClosed().subscribe((res) => {
-          if (!res) return;
-
-          if (res.accion === "guardarDocumento") {
-            this.guardarDocumento(documentoBase64, auditoria);
-          }
-        });
-      });
-  }
-
   verAuditoria(auditoria: Auditoria) {
     const auditoriaId = auditoria._id;
     this.router.navigate([


### PR DESCRIPTION
This pull request removes the `verDocumento` method from the `TablaSeguimientoComponent`. This method was responsible for fetching a document related to an audit in the MS MID `plantilla/plan-trabajo/:id` endpoint, displaying it in a modal, and handling the save action. No other changes are included.

- udistrital/sisifo_documentacion#779

* Removed the `verDocumento` method, which handled fetching and displaying audit documents in a modal, as well as saving the document if requested.