### PR TITLE
feat: adición de trazabilidad de payloads para validación en modo de notificaciones deshabilitadas udistrital/sisifo_documentacion#790

### DIFF
--- a/src/app/shared/services/notificaciones.service.ts
+++ b/src/app/shared/services/notificaciones.service.ts
@@ -129,7 +129,6 @@ export class NotificacionesService {
     destinatarios: DestinatariosEmail,
     variables: VariablesSolicitud
   ): Observable<any> {
-    if (!this.notificacionesHabilitadas) return new Observable(o => o.complete());
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_SOLICITUD_NOMBRE,
@@ -140,7 +139,12 @@ export class NotificacionesService {
         }
       ]
     };
-        
+
+    if (!this.notificacionesHabilitadas) {
+      console.log('[Notificaciones] DESHABILITADAS - enviarNotificacionSolicitud payload:', cuerpo);
+      return new Observable(o => o.complete());
+    }
+
     return this.notificacionesMidService.post(TEMPLATED_EMAIL_ENDPOINT, cuerpo);
   }
 
@@ -154,7 +158,6 @@ export class NotificacionesService {
     destinatarios: DestinatariosEmail,
     variables: VariablesRechazo
   ): Observable<any> {
-    if (!this.notificacionesHabilitadas) return new Observable(o => o.complete());
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_RECHAZO_NOMBRE,
@@ -165,6 +168,11 @@ export class NotificacionesService {
         }
       ]
     };
+
+    if (!this.notificacionesHabilitadas) {
+      console.log('[Notificaciones] DESHABILITADAS - enviarNotificacionRechazo payload:', cuerpo);
+      return new Observable(o => o.complete());
+    }
 
     return this.notificacionesMidService.post(TEMPLATED_EMAIL_ENDPOINT, cuerpo);
   }
@@ -179,7 +187,6 @@ export class NotificacionesService {
     destinatarios: DestinatariosEmail,
     variables: VariablesCartaRepresentacion
   ): Observable<any> {
-    if (!this.notificacionesHabilitadas) return new Observable(o => o.complete());
     const cuerpo: CuerpoTemplatedEmail = {
       Source: this.remitenteEmail,
       Template: PLANTILLA_CARTA_REPRESENTACION_NOMBRE,
@@ -190,6 +197,11 @@ export class NotificacionesService {
         }
       ]
     };
+
+    if (!this.notificacionesHabilitadas) {
+      console.log('[Notificaciones] DESHABILITADAS - enviarNotificacionCartaRepresentacion payload:', cuerpo);
+      return new Observable(o => o.complete());
+    }
 
     return this.notificacionesMidService.post(TEMPLATED_EMAIL_ENDPOINT, cuerpo);
   }


### PR DESCRIPTION
##  Trazabilidad de Notificaciones (Modo Debug)

Se mejoró el flujo de notificaciones deshabilitadas para permitir la validación técnica de los datos sin realizar envíos reales.

###  Cambios realizados:
* **Logging preventivo:** Se agregó un `console.log` estructurado que imprime el `cuerpo` (payload) completo justo antes del cortocircuito del Observable.
* **Capacidad de validación:** Ahora es posible verificar dinámicamente:
    * Resolución de correos (To, CC, BCC).
    * Consistencia del `ReplacementTemplateData`.
    * Selección correcta del template según el evento de auditoría.

###  Beneficio:
Facilita las pruebas de integración en ambientes locales/desarrollo al permitir "ver" qué se enviaría al MID de notificaciones sin saturar las bandejas de correo ni requerir el microservicio activo.

**Vínculo a documentación:** udistrital/sisifo_documentacion#790