### PR TITLE
fix: Se actualiza url de generación de auditoría especial inmediata y se añade payload 

### DIFF
--- a/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.component.ts
+++ b/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.component.ts
@@ -189,10 +189,20 @@ export class TablaAuditoriasEspecialesComponent {
     if (auditoriasConcretas.length > 0)
       return;
 
+    const generarAuditoriasDto = {
+      usuario_id: this.infoModal.usuarioId,
+      usuario_rol: this.infoModal.usuarioRol,
+      observacion: "Generación manual de auditoría",
+      estado_id_padre_actual: environment.AUDITORIA_PADRE_ESTADO.BORRADOR_ID,
+      estado_id_padre_nuevo: environment.AUDITORIA_PADRE_ESTADO.APROBADA_PAA_ID,
+      estado_id_hija_nuevo: environment.AUDITORIA_ESTADO.PROGRAMACION.POR_ASIGNAR,
+      fase_id: environment.AUDITORIA_FASE.PROGRAMACION,
+    };
+
     // Luego se genera la nueva auditoría concreta
     await firstValueFrom(
-      this.planAuditoriaService.post(
-        `auditoria-padre/${auditoriaPadre._id}/generar-auditoria`, {}
+      this.planAuditoriaMid.post(
+        `auditoria-padre/${auditoriaPadre._id}/generar-auditoria`, generarAuditoriasDto
       ).pipe(
         catchError((error) => throwError(() =>
           new Error("Error al generar la auditoría concreta.", error)


### PR DESCRIPTION
This pull request updates the process for generating a new "auditoría concreta" right after modifying a father audit with only one concrete audit in the `TablaAuditoriasEspecialesComponent`. The main change is that the request now includes a detailed DTO (data transfer object) with relevant user and state information, and uses a different service for the API call.

- udistrital/sisifo_documentacion#800

**Generation logic improvements:**
* Added a `generarAuditoriasDto` object that includes user ID, user role, observation, and various state and phase IDs, ensuring that all necessary context is sent with the API request.

**API integration update:**
* Switched the service used for the API call from `planAuditoriaService` to `planAuditoriaMid`, and updated the POST request to send the new DTO as the request body.