### PR TITLE
fix: Ajustes de hallazgos en pruebas funcionales de fase programación

### DIFF
--- a/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.ts
+++ b/src/app/modules/programacion/components/asignar-auditorias/modal-agregar-auditor/modal-agregar-auditor.component.ts
@@ -499,8 +499,6 @@ export class ModalAgregarAuditorComponent implements OnInit {
   
               // 4. Recalcular disponibles
               this.recomputeAuditoresDisponibles();
-
-              this.dialogRef.close({ saved: true });
   
               // 5. Feedback
               this.alertaService.showSuccessAlert(

--- a/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.utilidades.ts
+++ b/src/app/modules/programacion/components/auditorias-especiales/tabla-auditorias-especiales/tabla-auditorias-especiales.utilidades.ts
@@ -43,6 +43,10 @@ export const tituloAuditoriaEspecial = (
 export const cronogramaAuditoriaEspecial = (
   auditoria: AuditoriaEspecialTablaRow,
 ): string => {
+  if (auditoria.esAuditoriaConcreta) {
+    return "";
+  }
+
   if (Array.isArray(auditoria.cronograma_nombre) && auditoria.cronograma_nombre.length > 0) {
     return auditoria.cronograma_nombre.join(", ");
   }

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component.html
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component.html
@@ -12,65 +12,30 @@
     <h3 class="mx-2">Historial de observaciones</h3>
   </div>
 
-  <!-- Rechazos -->
-  @for (rechazo of rechazos; track rechazo) {
+  @for (observacion of observaciones; track observacion) {
     <div class="px-3 my-2">
       <div class="row">
         <div class="col-12 col-sm-12">
-          <div class="fondo-chip fondo-chip--rechazo mb-3">
+          <div [class]="observacion.estado.id === estadoRevision ? 'fondo-chip fondo-chip--revision mb-3' : 'fondo-chip fondo-chip--rechazo mb-3'">
             <div class="my-2">
               <p class="mb-2">
                 <b style="color: var(--md-accent-800)">Observaciones:</b>
               </p>
-              <p>{{ rechazo.observacion }}</p>
+              <p>{{ observacion.observacion }}</p>
               <div class="d-flex flex-wrap mt-4">
                 <div class="chip mb-sm">
                   <b>
-                    <mat-icon class="icon-chip">cancel</mat-icon>
-                    Rechazado por: {{ rechazo.usuario.nombre }}
+                    <mat-icon class="icon-chip">{{ observacion.estado.id === estadoRevision ? "rate_review" : "cancel" }}</mat-icon>
+                    Revisado por: {{ observacion.usuario.nombre }}
                   </b>
                 </div>
                 <div class="chip mb-sm">
                   <mat-icon class="icon-chip">person</mat-icon>
-                  <b>Rol: {{ rechazo.usuario_rol }}</b>
+                  <b>Rol: {{ observacion.usuario_rol || observacion.estado?.nombre }}</b>
                 </div>
                 <div class="chip mb-sm">
                   <mat-icon class="icon-chip">calendar_today</mat-icon>
-                  <b>Fecha:{{ rechazo.fecha_ejecucion_estado | date : "dd/MM/yyyy" }}</b>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  }
-
-  <!-- Revisiones Jefe con observación -->
-  @for (revision of revisionesJefe; track revision) {
-    <div class="px-3 my-2">
-      <div class="row">
-        <div class="col-12 col-sm-12">
-          <div class="fondo-chip fondo-chip--revision mb-3">
-            <div class="my-2">
-              <p class="mb-2">
-                <b style="color: var(--md-accent-800)">Observaciones:</b>
-              </p>
-              <p>{{ revision.observacion }}</p>
-              <div class="d-flex flex-wrap mt-4">
-                <div class="chip mb-sm">
-                  <b>
-                    <mat-icon class="icon-chip">rate_review</mat-icon>
-                    Revisado por: {{ revision.usuario.nombre }}
-                  </b>
-                </div>
-                <div class="chip mb-sm">
-                  <mat-icon class="icon-chip">person</mat-icon>
-                  <b>Rol: {{ revision.usuario_rol || revision.estado?.nombre }}</b>
-                </div>
-                <div class="chip mb-sm">
-                  <mat-icon class="icon-chip">calendar_today</mat-icon>
-                  <b>Fecha:{{ revision.fecha_ejecucion_estado | date : "dd/MM/yyyy" }}</b>
+                  <b>Fecha:{{ observacion.fecha_ejecucion_estado | date : "dd/MM/yyyy" }}</b>
                 </div>
               </div>
             </div>
@@ -81,7 +46,7 @@
   }
 
   <!-- Skeleton mientras carga -->
-  @if (rechazos.length === 0 && revisionesJefe.length === 0 && cargando) {
+  @if (observaciones.length === 0 && cargando) {
     @for (_ of [].constructor(numRechazos); track _) {
       <div class="px-3 my-2">
         <div class="row">

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/modal-lista-rechazos/modal-lista-rechazos.component.ts
@@ -2,7 +2,6 @@ import { Component, Inject, OnInit } from "@angular/core";
 import { MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { environment } from "src/environments/environment";
-import { forkJoin } from "rxjs";
 
 @Component({
     selector: "app-modal-lista-rechazos",
@@ -11,10 +10,11 @@ import { forkJoin } from "rxjs";
     standalone: false
 })
 export class ModalListaRechazosComponent implements OnInit {
-  rechazos: any[] = [];
-  revisionesJefe: any[] = [];
+  observaciones: any[] = [];
   numRechazos: number = 0;
   cargando: boolean = true;
+  estadoRevision = environment.PLAN_ESTADO.EN_REVISION_JEFE_ID;
+  estadoRechazo = environment.PLAN_ESTADO.RECHAZADO;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) private readonly planAuditoria: any,
@@ -28,23 +28,17 @@ export class ModalListaRechazosComponent implements OnInit {
 
   cargarObservaciones() {
     const planId = this.planAuditoria.id;
-    const estadoRechazadoId = environment.PLAN_ESTADO.RECHAZADO;
-    const estadoRevisionJefeId = environment.PLAN_ESTADO.EN_REVISION_JEFE_ID;
+    const estados = [this.estadoRevision, this.estadoRechazo].join("|");
 
-    const rechazos$ = this.planAuditoriaMid.get(
-      `plan-estado?query=plan_auditoria_id:${planId},estado_id:${estadoRechazadoId},activo:true&limit=0&sortby=fecha_ejecucion_estado&order=desc`
-    );
-
-    const revisionesJefe$ = this.planAuditoriaMid.get(
-      `plan-estado?query=plan_auditoria_id:${planId},estado_id:${estadoRevisionJefeId},activo:true&limit=0&sortby=fecha_ejecucion_estado&order=desc`
-    );
-
-    forkJoin([rechazos$, revisionesJefe$]).subscribe({
-      next: ([resRechazos, resRevisiones]) => {
-        this.rechazos = resRechazos?.Data ?? [];
-        // Solo mostrar revisiones del jefe que tengan observación no vacía
-        this.revisionesJefe = (resRevisiones?.Data ?? []).filter(
-          (r: any) => r.observacion && r.observacion.trim() !== ""
+    this.planAuditoriaMid.get(
+      `plan-estado?query=plan_auditoria_id:${planId},estado_id__in:${estados},activo:true&limit=0&sortby=fecha_ejecucion_estado&order=desc`
+    ).subscribe({
+      next: (res) => {
+        const data = res?.Data ?? [];
+        // Sólo mostrar revisiones del jefe que tengan observación no vacía
+        this.observaciones = data.filter((item: any) =>
+          item.estado.id === this.estadoRechazo
+          || item.observacion && item.observacion.trim() !== ""
         );
         this.cargando = false;
       },

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/registrar-auditorias/add-auditoria-modal/add-auditoria-modal.component.html
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/registrar-auditorias/add-auditoria-modal/add-auditoria-modal.component.html
@@ -165,7 +165,7 @@
 
 
             <!-- Cronograma de Actividades -->
-            <div class="col-12 col-md-6 col-xl-8">
+            <div class="col-12 col-md-8 col-xl-8">
               <div class="fondo-acento-50 d-flex justify-content-center my-3">
                 <b>Cronograma de actividades</b>
               </div>

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/revision-jefe/revision-jefe.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/revision-jefe/revision-jefe.component.ts
@@ -328,10 +328,10 @@ export class RevisionJefeComponent implements OnInit {
 
   async descargarTodo() {
     try {
-      const suffix = this.vigenciaNombre ? `-${this.vigenciaNombre.replace(/\s+/g, '-')}` : '';
+      const suffix = this.vigenciaNombre ? `${this.vigenciaNombre.replace(/\s+/g, '-')}` : '';
       await this.descargaService.descargarMultiplesArchivos(
         this.documentos,
-        `documentosPAA${suffix}.zip`,
+        `documentosPAA-${suffix}.zip`,
         suffix
       );
     } catch (error) {

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/revision-secretario/revision-secretario.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/revision-secretario/revision-secretario.component.ts
@@ -192,10 +192,10 @@ export class RevisionSecretarioComponent {
 
   async descargarTodo() {
     try {
-      const suffix = this.vigenciaNombre ? `-${this.vigenciaNombre.replace(/\s+/g, '-')}` : '';
+      const suffix = this.vigenciaNombre ? `${this.vigenciaNombre.replace(/\s+/g, '-')}` : '';
       await this.descargaService.descargarMultiplesArchivos(
         this.documentos,
-        `documentosPAA${suffix}.zip`,
+        `documentosPAA-${suffix}.zip`,
         suffix
       );
     } catch (error) {


### PR DESCRIPTION
This pull request refactors and improves the handling and display of observation histories in the audit plan consultation module. The main focus is on unifying the handling of rejection and review observations, simplifying the data fetching logic, and improving the UI for displaying these observations. Several minor UI and logic adjustments are also included.

- https://github.com/udistrital/sisifo_documentacion/issues/800

**Refactoring and unification of observation handling:**

* Combined the handling of rejections and jefe (chief) reviews into a single `observaciones` array, replacing the previous separate `rechazos` and `revisionesJefe` arrays, and updated the data fetching logic to retrieve both types in a single API call. [[1]](diffhunk://#diff-70d8cb68d811e68669740ab626fd25204154f5fe5c0d5fca8207dbcb07dde3f3L14-R17) [[2]](diffhunk://#diff-70d8cb68d811e68669740ab626fd25204154f5fe5c0d5fca8207dbcb07dde3f3L31-R41)
* Updated the modal template to iterate over the unified `observaciones` array, simplifying the display logic and ensuring consistent presentation for both rejection and review observations. [[1]](diffhunk://#diff-a856df867d99cb0a6003477721a3a52254dc76fc52e945e1fa801a329ae3f30dL15-R38) [[2]](diffhunk://#diff-a856df867d99cb0a6003477721a3a52254dc76fc52e945e1fa801a329ae3f30dL84-R49)

**UI and usability improvements:**

* Adjusted the display of the cronograma (schedule) in special audits to show an empty string when the audit is concrete, preventing irrelevant information from being shown.
* Modified the column width for the activities schedule in the add-audit modal for better layout and readability.

**Bug fixes and consistency:**

* Fixed the naming and formatting of downloaded zip files in both jefe and secretario revision components to ensure consistent and correct file names. [[1]](diffhunk://#diff-a02f61c89b08bf6bb3c9bb6c4ced0670c231ef9a8ec2694872ab1a4d2dfee0a9L331-R334) [[2]](diffhunk://#diff-3ed792991f1e48e9f032bffbb4557780d2c6267e2752d2b3125f692c08f10242L195-R198)
* Removed unnecessary import of `forkJoin` in the modal component as parallel requests are no longer needed.

**Other minor changes:**

* Removed an unwanted dialog close call in the auditor assignment modal to prevent premature dialog closure.