### PR TITLE
feat: Se reorganizan botones de planeación de actividades 

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.html
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.html
@@ -129,10 +129,6 @@
                 Crear Actividad
               </button>
             }
-            <button matStepperNext mat-flat-button color="primary" class="mx-2">
-              <mat-icon>{{ soloLectura ? 'arrow_forward_ios' : 'save' }}</mat-icon>
-              {{ soloLectura ? 'Continuar' : 'Guardar y continuar' }}
-            </button>
             @if (!soloLectura) {
               <button
                 class="mx-2"
@@ -143,6 +139,9 @@
                 <mat-icon>file_upload</mat-icon> Cargue Masivo
               </button>
             }
+            <button matStepperNext mat-flat-button color="primary" class="mx-2">
+              <mat-icon>arrow_forward_ios</mat-icon> Continuar
+            </button>
           </div>
         </mat-step>
 

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.html
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.html
@@ -146,10 +146,6 @@
                 Crear Actividad
               </button>
             }
-            <button matStepperNext mat-flat-button color="primary" class="mx-2">
-              <mat-icon>{{ soloLectura ? 'arrow_forward_ios' : 'save' }}</mat-icon>
-              {{ soloLectura ? 'Continuar' : 'Guardar y continuar' }}
-            </button>
             @if (!soloLectura) {
               <button
                 class="mx-2"
@@ -160,6 +156,9 @@
                 <mat-icon>file_upload</mat-icon> Cargue Masivo
               </button>
             }
+            <button matStepperNext mat-flat-button color="primary" class="mx-2">
+              <mat-icon>arrow_forward_ios</mat-icon> Continuar
+            </button>
           </div>
         </mat-step>
 


### PR DESCRIPTION
This pull request updates the navigation buttons in the "Actividades" sections of both the auditoría and seguimientop editing planning components. The main change is to simplify and standardize the "Continuar" button regardless of read-only mode, ensuring a consistent user experience.

- https://github.com/udistrital/sisifo_documentacion/issues/824

**Button behavior and UI consistency:**

* Replaced the conditional "Guardar y continuar" or "Continuar" button (which changed icon and label depending on `soloLectura`) with a single "Continuar" button using the `arrow_forward_ios` icon in `editar-auditoria.component.html` and moved it to the end of the page. [[1]](diffhunk://#diff-dabc44ea6e168e3fc5c12162643892c8a0167ab2b91dd337c89f53b824b46360L132-L135) [[2]](diffhunk://#diff-dabc44ea6e168e3fc5c12162643892c8a0167ab2b91dd337c89f53b824b46360R142-R144)
* Made the same update in `editar-seguimiento.component.html`, standardizing the button to always show "Continuar" with the `arrow_forward_ios` icon. [[1]](diffhunk://#diff-4b9a2cd393a61197b0e87a14fe9a6cdff8fd1f08be4ccc100cb3c9f0774c69d8L149-L152) [[2]](diffhunk://#diff-4b9a2cd393a61197b0e87a14fe9a6cdff8fd1f08be4ccc100cb3c9f0774c69d8R159-R161)