### PR TITLE
fix: 826 hallazgos en pruebas funcionales de planeación

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -54,6 +54,7 @@ interface DocumentoRevisionItem {
 })
 export class RevisionDocumentosComponent implements OnInit {
   auditoriaId: string = "";
+  consecutivoOci: string = "";
   estadoAuditoriaId!: number;
   selectedTab: number = 0;
   documentosVisibles: DocumentoRevisionItem[] = [];
@@ -90,6 +91,7 @@ export class RevisionDocumentosComponent implements OnInit {
   ngOnInit(): void {
     this.inicializarDatos();
     this.cargarEstadoAuditoria();
+    this.cargarConsecutivoOci();
   }
 
   inicializarDatos() {
@@ -112,6 +114,12 @@ export class RevisionDocumentosComponent implements OnInit {
           res.Data[0]?.estado_id ??
           environment.AUDITORIA_ESTADO.PROGRAMACION.BORRADOR_ID;
       });
+  }
+
+  cargarConsecutivoOci() {
+    this.planAuditoriaService
+      .get(`auditoria/${this.auditoriaId}`)
+      .subscribe((res) => { this.consecutivoOci = res.Data?.consecutivo_OCI ?? ""; });
   }
 
   verificarFirmaCartaYPreguntarAprobacion(cartas: DocumentoAdjuntoRevision[]) {
@@ -587,9 +595,12 @@ export class RevisionDocumentosComponent implements OnInit {
           fileName: documento.nombreArchivo,
         }));
 
+      const sufijo = this.consecutivoOci ? `oci-${this.consecutivoOci}` : "";
+      const sufijoNombre = sufijo ? `-${sufijo}` : "";
       await this.descargaService.descargarMultiplesArchivos(
         documentosDescarga,
-        "documentosAuditoria.zip"
+        `documentosAuditoria${sufijoNombre}.zip`,
+        sufijo,
       );
     } catch (error) {
       console.error("Error al crear el archivo ZIP:", error);

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -334,6 +334,8 @@ export class RevisionDocumentosComponent implements OnInit {
 
         return {
           nombre: `Carta de representación ${dependenciaNombre}`,
+          nombreDescarga: "carta-representación",
+          presufijo: dependenciaNombre,
           tipoId: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
           documentoId: documento._id,
           botones: [{
@@ -374,6 +376,8 @@ export class RevisionDocumentosComponent implements OnInit {
           descripcion:
             "Revise y cargue la carta de representación firmada para cada dependencia.",
           tabs,
+          sufijo: `oci-${this.consecutivoOci}`,
+          nombreArchivoDescarga: "cartas-representación",
           tipo: environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION,
           textoBotonCerrar: "Cerrar",
           accionesFooter: [

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
@@ -182,7 +182,11 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
           );
           
         });
-        this.auditoria = res.Data;
+        const datosActualizados = res?.Data;
+        if (datosActualizados) {
+          this.auditoria = { ...this.auditoria, ...datosActualizados };
+        }
+
         this.paso1Guardado = true;
         this.stepper.next();
       });

--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.html
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.html
@@ -64,16 +64,18 @@
           @if (mostrarBotones) {
             <div class="row">
               <div class="col-12 my-4">
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  class="mx-2 width-100-md"
-                  style="border: 1px solid var(--md-primary-500)"
-                  (click)="abrirModalRechazo()"
-                  >
-                  <mat-icon>disabled_by_default</mat-icon>
-                  Rechazar {{ tipoEvaluacion }}
-                </button>
+                @if (mostrarBotonRechazo) {
+                  <button
+                    mat-stroked-button
+                    color="primary"
+                    class="mx-2 width-100-md"
+                    style="border: 1px solid var(--md-primary-500)"
+                    (click)="abrirModalRechazo()"
+                    >
+                    <mat-icon>disabled_by_default</mat-icon>
+                    Rechazar {{ tipoEvaluacion }}
+                  </button>
+                }
                 <button
                   class="mx-2 width-100-md mt-md"
                   mat-raised-button

--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
@@ -47,6 +47,7 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
   docCartaPresentacion: string = "";
   docCompromisoEstico: string = "";
   mostrarBotones: boolean = false;
+  mostrarBotonRechazo: boolean = false;
 
   constructor(
     public readonly dialog: MatDialog,
@@ -537,6 +538,7 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
     };
     // retorna true, si el rol coincide con el estado de revision del rol
     this.mostrarBotones = condicionesVisibilidad[role]?.includes(estadoAuditoriaId) || false;
+    this.mostrarBotonRechazo = this.mostrarBotones && this.role === environment.ROL.JEFE;
   }
 
   cargarDocumentos() {

--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
@@ -32,6 +32,7 @@ import { Auditoria } from "src/app/shared/data/models/auditoria";
 })
 export class RevisionDocumentosSeguimientoComponent implements OnInit {
   auditoriaId: string = "";
+  consecutivoOci: string = "";
   estadoAuditoriaId!: number;
   tipoEvaluacionId!: number;
   tipoEvaluacion!: string;
@@ -70,6 +71,7 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
   ngOnInit(): void {
     this.inicializarDatos();
     this.cargarEstadoAuditoria();
+    this.cargarConsecutivoOci();
   }
 
   inicializarDatos() {
@@ -104,6 +106,12 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
           this.mostrarAcciones(this.role, this.estadoAuditoriaId);
         }
       });
+  }
+
+  cargarConsecutivoOci() {
+    this.planAuditoriaService
+      .get(`auditoria/${this.auditoriaId}`)
+      .subscribe((res) => { this.consecutivoOci = res.Data?.consecutivo_OCI ?? ""; });
   }
 
   preguntarAprobacionAuditoria() {
@@ -572,9 +580,13 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
 
   async descargarTodo() {
     try {
+      const sufijo = this.consecutivoOci ? `oci-${this.consecutivoOci}` : "";
+      const sufijoNombre = sufijo ? `-${sufijo}` : "";
+
       await this.descargaService.descargarMultiplesArchivos(
         this.documentos,
-        "documentosAuditoria.zip"
+        `documentosAuditoria${sufijoNombre}.zip`,
+        sufijo,
       );
     } catch (error) {
       console.error("Error al crear el archivo ZIP:", error);

--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.utilidades.ts
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.utilidades.ts
@@ -3,14 +3,14 @@ import { environment } from "src/environments/environment";
 const configAuditado = {
   estadoAprobacion: environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_AUDITADO,
   preguntaAprobacion: {
-    auditoria: "¿Está seguro(a) de firmar y enviar auditoría?",
-    informe: "¿Está seguro(a) de firmar y enviar informe de auditoría?",
+    auditoria: "¿Está seguro(a) de aprobar y enviar esta auditoría?",
+    informe: "¿Está seguro(a) de aprobar y enviar este informe de auditoría?",
   },
   mensajeAprobacion: {
     auditoria: "La auditoría fue enviada al auditor",
     informe: "El informe de auditoría fue enviado al auditor",
   },
-  botonAprobacion: "Firmar y enviar",
+  botonAprobacion: "Aprobar y enviar",
 };
 
 const configJefe = {

--- a/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documentos/modal-ver-documentos.component.ts
@@ -48,6 +48,8 @@ export interface CargueAdjuntoTabConfig {
 
 export interface TabDocumento {
   nombre: string;
+  nombreDescarga?: string;
+  presufijo?: string;
   tipoId: number;
   fecha_subida?: string;
   obligatorio?: boolean;
@@ -62,6 +64,7 @@ export interface ModalVerDocumentosData {
   titulo?: string;
   descripcion?: string;
   sufijo?: string;
+  nombreArchivoDescarga?: string;
   tabs?: TabDocumento[];
   inferTabs?: boolean;
   tipo?: number;
@@ -92,6 +95,7 @@ export class ModalVerDocumentosComponent implements OnInit {
   titulo: string = "Ver documentos";
   descripcion: string = "Documentos";
   suffix: string = "";
+  nombreArchivoDescarga: string = "documentos";
   textoBotonCerrar: string = "Regresar";
   consultarPorTipo: boolean = false;
   tabs: TabDocumento[] = [];
@@ -112,6 +116,9 @@ export class ModalVerDocumentosComponent implements OnInit {
     if (data.textoBotonCerrar) this.textoBotonCerrar = data.textoBotonCerrar;
     if (data.accionesFooter) this.accionesFooter = data.accionesFooter;
     if (data.tipo) this.consultarPorTipo = true;
+    if (data.nombreArchivoDescarga) {
+      this.nombreArchivoDescarga = data.nombreArchivoDescarga;
+    }
     if (data.sufijo) {
       this.suffix = data.sufijo ? data.sufijo : '';
     }
@@ -315,15 +322,42 @@ export class ModalVerDocumentosComponent implements OnInit {
   }
 
   async descargarTodo() {
-    const suffixNormalizado = this.suffix ? `-${this.suffix.replace(/\s+/g, '-')}` : '';
     try {
+      const documentosDescarga = this.obtenerDocumentosAsignadosATabs();
+      const suffixNormalizado = this.suffix ? `-${this.suffix.replace(/\s+/g, '-')}` : '';
+
       await this.descargaService.descargarMultiplesArchivos(
-        this.documentos,
-        `documentos${suffixNormalizado}.zip`,
+        documentosDescarga,
+        `${this.nombreArchivoDescarga}${suffixNormalizado}.zip`,
         this.suffix,
       );
     } catch (error) {
       console.error("Error al crear el archivo ZIP:", error);
     }
   }
+
+  private obtenerDocumentosAsignadosATabs(): { base64: string; tipo_id: number; fileName: string }[] {
+    return this.tabs
+      .map((tab, index) => {
+        const documento = this.documentoInfoPorTab[index];
+        if (!documento?.base64) {
+          return null;
+        }
+
+        const nombreBase = tab.nombreDescarga ?? tab.nombre;
+        const segmentosNombre = [nombreBase];
+
+        if (tab.presufijo?.trim()) {
+          segmentosNombre.push(tab.presufijo.trim());
+        }
+
+        return {
+          base64: documento.base64,
+          tipo_id: tab.tipoId,
+          fileName: segmentosNombre.join("-"),
+        };
+      })
+      .filter((documento): documento is { base64: string; tipo_id: number; fileName: string } => !!documento);
+  }
+
 }


### PR DESCRIPTION
This pull request introduces improvements to the document review workflow, especially for users with the auditee role, and updates approval messaging for clarity. The main changes include conditional display of the rejection button, enhanced merging of audit data, and clearer approval prompts.

- udistrital/sisifo_documentacion#826

**Document review workflow enhancements:**

* Added a new `mostrarBotonRechazo` property in `RevisionDocumentosSeguimientoComponent` and logic to show the "Rechazar" button only when the user role is "Jefe" and other visibility conditions are met, effectively removing it for the auditee roles. [[1]](diffhunk://#diff-a31a87152d4e5f1298ef6783881fc5a2ee6548a17b5dddaf7f2e21bd9dec344dR50) [[2]](diffhunk://#diff-a31a87152d4e5f1298ef6783881fc5a2ee6548a17b5dddaf7f2e21bd9dec344dR541) [[3]](diffhunk://#diff-868f517f8175192fdc21e07f069ec28d6f9ac4433362b5460a6986d92fd9b8d5R67) [[4]](diffhunk://#diff-868f517f8175192fdc21e07f069ec28d6f9ac4433362b5460a6986d92fd9b8d5R78)

**Audit data handling:**

* Improved merging of updated audit data in `EditarSeguimientoComponent` by safely combining existing and new data, preventing overwrites of unchanged fields.

**Approval messaging updates:**

* Updated confirmation prompts and button text for audit approval actions to use "Aprobar y enviar" instead of "Firmar y enviar" for better clarity in `revision-documentos.utilidades.ts`.