### PR TITLE
fix: 826 correcciones de hallazgos de pruebas funcionales

### DIFF
--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
@@ -550,11 +550,83 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
   }
 
   cargarDocumentos() {
+    this.documentos = [];
+    this.docProgramaTrabajo = "";
+    this.docSolicitudInformacion = "";
+    this.docCartaPresentacion = "";
+    this.docCompromisoEstico = "";
+
+    const tipoDocumentoMap = {
+      [environment.TIPO_DOCUMENTO_PARAMETROS.SOLICITUD_INFORMACION]: "docSolicitudInformacion",
+      [environment.TIPO_DOCUMENTO_PARAMETROS.COMPROMISO_ETICO]: "docCompromisoEstico",
+    };
+
+    if (
+      this.role === environment.ROL.JEFE_DEPENDENCIA ||
+      this.role === environment.ROL.ASISTENTE_DEPENDENCIA
+    ) {
+      this.cargarDocumentosAuditado(tipoDocumentoMap);
+      return;
+    }
+
     this.referenciaPdfService
-      .consultarDocumentos(this.auditoriaId)
+      .consultarDocumentos(this.auditoriaId, { deduplicarPorTipo: false })
       .subscribe(async (res) => {
-        const promesas = res.map(async (documento) => {
+        const promesas = res.map(async (documento: any) => {
+          if (!documento?.nuxeo_enlace) {
+            return;
+          }
+
           const base64 = await this.nuxeoService.obtenerPorUUID(documento.nuxeo_enlace);
+
+          if (!base64) {
+            return;
+          }
+
+          const propiedad = tipoDocumentoMap[documento.tipo_id];
+          if (!propiedad) {
+            return; // ignorar tipos que no sean Solicitud o Compromiso
+          }
+
+          (this as any)[propiedad] = base64;
+
+          this.documentos.push({ base64, tipo_id: documento.tipo_id });
+        });
+
+        await Promise.all(promesas);
+      });
+  }
+
+  private async cargarDocumentosAuditado(tipoDocumentoMap: any) {
+    const personaId = await this.userService.getPersonaId();
+    let cargoId: number | undefined;
+
+    switch (this.role) {
+      case environment.ROL.JEFE_DEPENDENCIA:
+        cargoId = environment.CARGO.JEFE_DEPENDENCIA_ID;
+        break;
+      case environment.ROL.ASISTENTE_DEPENDENCIA:
+        cargoId = environment.CARGO.ASISTENTE_DEPENDENCIA_ID;
+        break;
+    }
+
+    this.planAuditoriaMid
+      .get(`auditado/${personaId}/documento?auditoria_id=${this.auditoriaId}&cargo_id=${cargoId}`)
+      .subscribe(async (res: any[]) => {
+        const promesas = res.map(async (documento: any) => {
+          if (!documento?.nuxeo_enlace) {
+            return;
+          }
+
+          const base64 = await this.nuxeoService.obtenerPorUUID(documento.nuxeo_enlace);
+
+          const propiedad = tipoDocumentoMap[documento.tipo_id];
+          if (!base64 || !propiedad) {
+            return;
+          }
+
+          (this as any)[propiedad] = base64;
+
           this.documentos.push({ base64, tipo_id: documento.tipo_id });
         });
 

--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
@@ -154,8 +154,13 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
     mensajeAprobacion: string
   ) {
     try {
-      for (const estado of estadoAprobacion) {
-        await this.aprobarAuditoria(estado, mensajeAprobacion);
+      for (let i = 0; i < estadoAprobacion.length; i++) {
+        const esUltimoEstado = i === estadoAprobacion.length - 1;
+        await this.aprobarAuditoria(
+          estadoAprobacion[i],
+          mensajeAprobacion,
+          esUltimoEstado
+        );
       }
       const ultimoEstado = estadoAprobacion[estadoAprobacion.length - 1];
       if (ultimoEstado === environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO) {
@@ -475,24 +480,36 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
     });
   }
 
-  async aprobarAuditoria(estadoAprobacion: number, mensajeAprobacion: string) {
-    try {
-      const auditoriaEstado =
-        this.construirObjetoAuditoriaEstado(estadoAprobacion);
+  aprobarAuditoria(
+    estadoAprobacion: number,
+    mensajeAprobacion: string,
+    mostrarMensaje: boolean = true
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const auditoriaEstado = this.construirObjetoAuditoriaEstado(estadoAprobacion);
 
       this.planAuditoriaService
         .post("auditoria-estado", auditoriaEstado)
-        .subscribe(() => {
-          this.alertService.showSuccessAlert(
-            mensajeAprobacion,
-            "Auditoría enviada"
-          ).then(() => {
-            this.router.navigate([`/planeacion/seguimiento`]);
-          });
+        .subscribe({
+          next: () => {
+            if (mostrarMensaje) {
+              this.alertService.showSuccessAlert(
+                mensajeAprobacion,
+                "Auditoría enviada"
+              ).then(() => {
+                this.router.navigate([`/planeacion/seguimiento`]);
+                resolve();
+              });
+            } else {
+              resolve();
+            }
+          },
+          error: (error: Error) => {
+            this.alertService.showErrorAlert("Error al aprobar el plan.");
+            reject(error);
+          }
         });
-    } catch (error) {
-      this.alertService.showErrorAlert("Error al aprobar el plan.");
-    }
+    });
   }
 
   construirObjetoAuditoriaEstado(estadoAprobacion: number) {

--- a/src/app/shared/utils/accionesPorRolYEstado.ts
+++ b/src/app/shared/utils/accionesPorRolYEstado.ts
@@ -273,16 +273,13 @@ export const accionesPlaneacion: {
 
   [environment.ROL.JEFE_DEPENDENCIA]: {
     [environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO]: [
-      "Ver Auditoría",
       "Revisar Auditoría",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_AUDITADO]: [
-      "Ver Auditoría",
       "Ver Documentos",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_JEFE]: [
-      "Ver Auditoría",
-      "Revisar Auditoría",
+      "Ver Documentos",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.RECHAZADO_PROGRAMA_JEFE]: [
       "Ver Documentos",
@@ -292,19 +289,17 @@ export const accionesPlaneacion: {
 
   [environment.ROL.ASISTENTE_DEPENDENCIA]: {
     [environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO]: [
-      "Ver Auditoría",
       "Revisar Auditoría",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_AUDITADO]: [
-      "Ver Auditoría",
       "Ver Documentos",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_JEFE]: [
-      "Ver Auditoría",
-      "Revisar Auditoría",
+      "Ver Documentos",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.RECHAZADO_PROGRAMA_JEFE]: [
       "Ver Documentos",
+      "Historial de Observaciones",
     ],
   },
 };


### PR DESCRIPTION
This pull request introduces several improvements to the document review and approval workflow in the planning module, with a focus on role-based document loading, enhanced approval handling, and updates to available actions for specific roles and states.

- udistrital/sisifo_documentacion#826

**Document loading and handling improvements:**

* Refactored `cargarDocumentos` to clear previous state, deduplicate by document type, and load documents differently for "Jefe de Dependencia" and "Asistente Dependencia" roles, using a new `cargarDocumentosAuditado` method to fetch documents relevant to the user's role.
* Improved document fetching by checking for valid `nuxeo_enlace` links and only processing recognized document types, ensuring only relevant documents are loaded and displayed.

**Approval workflow enhancements:**

* Updated `aprobarAuditorias` to pass an `esUltimoEstado` flag to `aprobarAuditoria`, allowing for conditional navigation and messaging based on whether the approval is for the final state in the sequence.
* Refactored `aprobarAuditoria` to return a Promise, handle both success and error cases more robustly, and optionally suppress success messages and navigation when not processing the final approval state.

**Role-based action updates:**

* Modified `accionesPlaneacion` to remove or replace certain actions for "Jefe de Dependencia" and "Asistente Dependencia" roles, such as removing "Ver Auditoría" and adding "Ver Documentos" or "Historial de Observaciones" in appropriate states, to better reflect the intended workflow and permissions. [[1]](diffhunk://#diff-0369d1f4f803eb6acea202efcf5b2cb6a63fbf6f49391367843e385848bcd0bbL276-R282) [[2]](diffhunk://#diff-0369d1f4f803eb6acea202efcf5b2cb6a63fbf6f49391367843e385848bcd0bbL295-R302)