### PR TITLE
fix: 837 correcciones varias mrpocketmonsters

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
@@ -545,10 +545,11 @@ export class EditarAuditoriaComponent implements OnInit, AfterViewInit {
           auditoria: this.planAuditoriaService.get(`auditoria/${auditoriaId}`),
           vigencias: this.parametrosUtilsService.getVigencias(),
           nombreRemitente: of(tercero.NombreCompleto),
+          jefeOCI: this.tercerosService.getJefeOCI(),
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente }: any) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         const vigenciaId = datosAuditoria?.vigencia_id;
@@ -556,7 +557,7 @@ export class EditarAuditoriaComponent implements OnInit, AfterViewInit {
         const vigenciaNombre = vigenciaObj?.Nombre || (vigenciaId ? String(vigenciaId) : "");
 
         const destinatarios: DestinatariosEmail = this.tercerosService.combinarDestinatarios(
-          [],
+          [jefeOCI.UsuarioWSO2],
           environment.NOTIFICACION_PROGRAMA_TRABAJO_ENVIO_JEFE_DESTINATARIOS
         );
 

--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/editar-auditoria.component.ts
@@ -549,7 +549,7 @@ export class EditarAuditoriaComponent implements OnInit, AfterViewInit {
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         const vigenciaId = datosAuditoria?.vigencia_id;

--- a/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/revision-documentos/revision-documentos.component.ts
@@ -779,6 +779,12 @@ export class RevisionDocumentosComponent implements OnInit {
         const vigenciaId = datosAuditoria?.vigencia_id;
         const vigenciaObj = vigencias.find((v: any) => v.Id === vigenciaId);
         const vigenciaNombre = vigenciaObj?.Nombre || (vigenciaId ? String(vigenciaId) : "");
+        dependenciasInfo.forEach((dep) => 
+          datosAuditoria.correo_complementario?.forEach((correo: any) => {
+            if (correo.dependencia_id === dep.dependencia_id)
+              dep.correo_complementario = correo.correo;
+          })
+        );
 
         const correosAuditores$ = listaAuditores.length > 0
           ? forkJoin(

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -673,7 +673,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         // Resolver vigencia igual que el PAA — desde ParametrosUtilsService

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -11,7 +11,7 @@ import { MatTableDataSource } from "@angular/material/table";
 import { colocacionesContructorTabla } from "./tabla-auditorias-internas.utilidades";
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { MatDialog } from "@angular/material/dialog";
-import { ModalHistorialRechazosComponent } from "src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component";
+import { HistorialRechazosData, ModalHistorialRechazosComponent } from "src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component";
 import { ModalVerDocumentoComponent } from "src/app/shared/elements/components/dialogs/modal-ver-documento/modal-ver-documento.component";
 import { Router } from "@angular/router";
 import { Auditoria, tituloYSubtituloAuditoria } from "src/app/shared/data/models/auditoria";
@@ -514,10 +514,17 @@ export class TablaAuditoriasInternasComponent implements OnInit {
       width: "1000px",
       data: {
         auditoriaId: auditoria._id,
-        estadoIds: [environment.AUDITORIA_ESTADO.PLANEACION.RECHAZADO_PROGRAMA_JEFE],
+        estadoEndpoint: "auditoria-estado",
+        auditoriaIdReferencia: "auditoria_id",
+        estadoRevisionIds: [
+          environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_JEFE,
+        ],
+        estadoRechazoIds: [
+          environment.AUDITORIA_ESTADO.PLANEACION.RECHAZADO_PROGRAMA_JEFE,
+        ],
         titulo: "Motivos de rechazo y observaciones",
         descripcion: `Lista de motivos de rechazo y observaciones - Auditoría ${auditoria.titulo}`,
-      },
+      } as HistorialRechazosData,
     });
   }
 

--- a/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/tabla-auditorias-internas/tabla-auditorias-internas.component.ts
@@ -673,7 +673,7 @@ export class TablaAuditoriasInternasComponent implements OnInit {
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         // Resolver vigencia igual que el PAA — desde ParametrosUtilsService

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
@@ -477,10 +477,11 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
           auditoria: this.planAuditoriaService.get(`auditoria/${auditoriaId}`),
           vigencias: this.parametrosUtilsService.getVigencias(),
           nombreRemitente: of(tercero.NombreCompleto),
+          jefeOCI: this.tercerosService.getJefeOCI(),
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente }: any) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         const vigenciaId = datosAuditoria?.vigencia_id;
@@ -488,7 +489,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
         const vigenciaNombre = vigenciaObj?.Nombre || (vigenciaId ? String(vigenciaId) : "");
 
         const destinatarios: DestinatariosEmail = this.tercerosService.combinarDestinatarios(
-          [],
+          [jefeOCI.UsuarioWSO2],
           environment.NOTIFICACION_PROGRAMA_TRABAJO_ENVIO_JEFE_DESTINATARIOS
         );
 

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/editar-seguimiento.component.ts
@@ -481,7 +481,7 @@ export class EditarSeguimientoComponent implements OnInit, AfterViewInit {
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         const vigenciaId = datosAuditoria?.vigencia_id;

--- a/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/revision-documentos/revision-documentos.component.ts
@@ -347,6 +347,12 @@ export class RevisionDocumentosSeguimientoComponent implements OnInit {
         const vigenciaId = datosAuditoria?.vigencia_id;
         const vigenciaObj = vigencias.find((v: any) => v.Id === vigenciaId);
         const vigenciaNombre = vigenciaObj?.Nombre || (vigenciaId ? String(vigenciaId) : "");
+        dependenciasInfo.forEach((dep) => 
+          datosAuditoria.correo_complementario?.forEach((correo: any) => {
+            if (correo.dependencia_id === dep.dependencia_id)
+              dep.correo_complementario = correo.correo;
+          })
+        );
 
         console.log(
           "[notificarAceptacionAuditado - SEGUIMIENTO] auditoriaId:", auditoriaId,

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
@@ -11,7 +11,7 @@ import { MatTableDataSource } from "@angular/material/table";
 import { colocacionesContructorTabla } from "./tabla-seguimiento.utilidades";
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { MatDialog } from "@angular/material/dialog";
-import { ModalHistorialRechazosComponent } from "src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component";
+import { HistorialRechazosData, ModalHistorialRechazosComponent } from "src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component";
 import { Router } from "@angular/router";
 import { Auditoria } from "src/app/shared/data/models/auditoria";
 import { AlertService } from "src/app/shared/services/alert.service";
@@ -426,10 +426,17 @@ export class TablaSeguimientoComponent implements OnInit {
       width: "1000px",
       data: {
         auditoriaId: auditoria._id,
-        estadoIds: [environment.AUDITORIA_ESTADO.PLANEACION.RECHAZADO_PROGRAMA_JEFE],
+        estadoEndpoint: "auditoria-estado",
+        auditoriaIdReferencia: "auditoria_id",
+        estadoRevisionIds: [
+          environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_JEFE,
+        ],
+        estadoRechazoIds: [
+          environment.AUDITORIA_ESTADO.PLANEACION.RECHAZADO_PROGRAMA_JEFE
+        ],
         titulo: "Motivos de rechazo y observaciones",
         descripcion: `Lista de motivos de rechazo y observaciones - Auditoría ${auditoria.titulo}`,
-      },
+      } as HistorialRechazosData,
     });
   }
 

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
@@ -586,7 +586,7 @@ export class TablaSeguimientoComponent implements OnInit {
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         const vigenciaId = datosAuditoria?.vigencia_id;

--- a/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/tabla-seguimiento/tabla-seguimiento.component.ts
@@ -586,7 +586,7 @@ export class TablaSeguimientoComponent implements OnInit {
         })
       ),
 
-      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }: any) => {
+      exhaustMap(({ auditoria, vigencias, nombreRemitente, jefeOCI }) => {
         const datosAuditoria: Auditoria = auditoria?.Data;
 
         const vigenciaId = datosAuditoria?.vigencia_id;

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan-auditoria.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/consulta-plan-auditoria.component.ts
@@ -10,7 +10,7 @@ import { Plan } from "src/app/shared/data/models/plan-anual-auditoria/plan-anual
 import { environment } from "src/environments/environment";
 import { AlertService } from "src/app/shared/services/alert.service";
 import { MatDialog } from "@angular/material/dialog";
-import { ModalHistorialRechazosComponent } from "src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component";
+import { HistorialRechazosData, ModalHistorialRechazosComponent } from "src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component";
 import { MatPaginator } from "@angular/material/paginator";
 import { RolService } from "src/app/core/services/rol.service";
 import { accionesProgramacion } from "src/app/shared/utils/accionesPorRolYEstado";
@@ -492,13 +492,17 @@ export class ConsultaPlanAuditoriaComponent implements OnInit {
       width: "1000px",
       data: {
         auditoriaId: plan.id,
-        estadoIds: [
+        estadoEndpoint: "plan-estado",
+        auditoriaIdReferencia: "plan_auditoria_id",
+        estadoRevisionIds: [
+          environment.PLAN_ESTADO.EN_REVISION_JEFE_ID,
+        ],
+        estadoRechazoIds: [
           environment.PLAN_ESTADO.RECHAZADO,
         ],
-        tipoEntidad: "plan",
         titulo: "Historial de observaciones",
         descripcion: `Historial de observaciones - Plan Anual de Auditoría ${plan.vigencia}`,
-      },
+      } as HistorialRechazosData,
       autoFocus: false,
     });
   }

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/registrar-plan/registrar-plan.component.html
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/registrar-plan/registrar-plan.component.html
@@ -40,7 +40,7 @@
               </div>
               <div style="color: var(--md-primary-900)" class="mx-2">
                 <h3 class="mb-1">{{ item.title }}</h3>
-                <p>{{ item.content }}</p>
+                <p style="white-space: pre-line">{{ item.content }}</p>
               </div>
             </div>
           }

--- a/src/app/modules/programacion/components/consulta-plan-auditoria/revision-secretario/modal-aprobacion-secretario/modal-aprobacion-secretario.component.ts
+++ b/src/app/modules/programacion/components/consulta-plan-auditoria/revision-secretario/modal-aprobacion-secretario/modal-aprobacion-secretario.component.ts
@@ -83,7 +83,7 @@ export class ModalAprobacionSecretarioComponent {
           response[0],
           "Plan Auditoria",
           this.infoModal.planAuditoriaId,
-          6820
+          environment.TIPO_DOCUMENTO.ACTA_COMITE_COORDINADOR
         );
       },
       error: (error) => {

--- a/src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component.html
+++ b/src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component.html
@@ -12,77 +12,56 @@
     <h3 class="mx-2">Historial de observaciones</h3>
   </div>
 
-  <div *ngIf="cargando" class="spinner-container">
-    <mat-progress-spinner diameter="40" mode="indeterminate"></mat-progress-spinner>
-  </div>
-
-  <ng-container *ngIf="!cargando">
-    <div *ngIf="rechazos.length === 0 && revisionesJefe.length === 0" class="sin-rechazos">
-      No se encontraron observaciones.
+  @if (cargando) {
+    <div class="spinner-container">
+      <mat-progress-spinner diameter="40" mode="indeterminate"></mat-progress-spinner>
     </div>
+  }
+  @else {
+    @if (observaciones.length === 0) {
+      <div class="sin-rechazos">
+        No se encontraron observaciones.
+      </div>
+    }
 
-    <div *ngFor="let rechazo of rechazos" class="px-3 my-2">
-      <div class="row">
-        <div class="col-12 col-sm-12">
-          <div class="fondo-chip fondo-chip--rechazo mb-3">
-            <div class="my-2">
-              <p class="mb-2">
-                <b style="color: var(--md-accent-800)">Observaciones:</b>
-              </p>
-              <p>{{ rechazo.observacion || 'Sin observación' }}</p>
-              <div class="d-flex flex-wrap mt-4">
-                <div class="chip mb-sm">
-                  <b>
-                    <mat-icon class="icon-chip">cancel</mat-icon>
-                    Rechazado por: {{ rechazo.usuario?.nombre || 'Usuario' }}
-                  </b>
-                </div>
-                <div class="chip mb-sm">
-                  <mat-icon class="icon-chip">person</mat-icon>
-                  <b>Rol: {{ rechazo.usuario_rol || 'No definido' }}</b>
-                </div>
-                <div class="chip mb-sm">
-                  <mat-icon class="icon-chip">calendar_today</mat-icon>
-                  <b>Fecha: {{ rechazo.fecha_ejecucion_estado | date : 'dd/MM/yyyy' }}</b>
+    @else{
+      @for (observacion of observaciones; track observacion) {
+        <div class="px-3 my-2">
+          <div class="row">
+            <div class="col-12 col-sm-12">
+              <div
+                [class]="`fondo-chip fondo-chip--${isRechazo(observacion) ? 'rechazo' : 'revision'} mb-3`"
+              >
+                <div class="my-2">
+                  <p class="mb-2">
+                    <b style="color: var(--md-accent-800)">Observaciones:</b>
+                  </p>
+                  <p>{{ observacion.observacion || 'Sin observación' }}</p>
+                  <div class="d-flex flex-wrap mt-4">
+                    <div class="chip mb-sm">
+                      <b>
+                        <mat-icon class="icon-chip">{{ isRechazo(observacion) ? 'cancel' : 'rate_review' }}</mat-icon>
+                        Revisado por: {{ observacion.usuario?.nombre || 'Usuario' }}
+                      </b>
+                    </div>
+                    <div class="chip mb-sm">
+                      <mat-icon class="icon-chip">person</mat-icon>
+                      <b>Rol: {{ observacion.usuario_rol || 'No definido' }}</b>
+                    </div>
+                    <div class="chip mb-sm">
+                      <mat-icon class="icon-chip">calendar_today</mat-icon>
+                      <b>Fecha: {{ observacion.fecha_ejecucion_estado | date : 'dd/MM/yyyy' }}</b>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      }
+    }
+  }
 
-    <div *ngFor="let revision of revisionesJefe" class="px-3 my-2">
-      <div class="row">
-        <div class="col-12 col-sm-12">
-          <div class="fondo-chip fondo-chip--revision mb-3">
-            <div class="my-2">
-              <p class="mb-2">
-                <b style="color: var(--md-primary-800)">Observaciones:</b>
-              </p>
-              <p>{{ revision.observacion || 'Sin observación' }}</p>
-              <div class="d-flex flex-wrap mt-4">
-                <div class="chip mb-sm">
-                  <b>
-                    <mat-icon class="icon-chip">comment</mat-icon>
-                    En Revisión por Jefe: {{ revision.usuario?.nombre || 'Usuario' }}
-                  </b>
-                </div>
-                <div class="chip mb-sm">
-                  <mat-icon class="icon-chip">person</mat-icon>
-                  <b>Rol: {{ revision.usuario_rol || 'No definido' }}</b>
-                </div>
-                <div class="chip mb-sm">
-                  <mat-icon class="icon-chip">calendar_today</mat-icon>
-                  <b>Fecha: {{ revision.fecha_ejecucion_estado | date : 'dd/MM/yyyy' }}</b>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </ng-container>
 </ng-template>
 
 <ng-template #footerDeModal>

--- a/src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-historial-rechazos/modal-historial-rechazos.component.ts
@@ -1,13 +1,13 @@
 import { Component, Inject, OnInit } from "@angular/core";
 import { MAT_DIALOG_DATA } from "@angular/material/dialog";
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
-import { environment } from "src/environments/environment";
-import { forkJoin } from "rxjs";
 
-interface HistorialRechazosData {
+export interface HistorialRechazosData {
   auditoriaId: string;
-  estadoIds: number[];
-  tipoEntidad?: "auditoria" | "plan";
+  estadoEndpoint: string;
+  auditoriaIdReferencia: string;
+  estadoRevisionIds: number[];
+  estadoRechazoIds: number[];
   titulo?: string;
   descripcion?: string;
 }
@@ -19,8 +19,7 @@ interface HistorialRechazosData {
   standalone: false,
 })
 export class ModalHistorialRechazosComponent implements OnInit {
-  rechazos: any[] = [];
-  revisionesJefe: any[] = [];
+  observaciones: any[] = [];
   cargando = true;
   titulo: string;
   descripcion: string = "";
@@ -38,38 +37,38 @@ export class ModalHistorialRechazosComponent implements OnInit {
   }
 
   cargarRechazos() {
-    const { auditoriaId, estadoIds, tipoEntidad = "auditoria" } = this.data;
-    const estadoQuery = estadoIds.join("|");
-    const isPlan = tipoEntidad === "plan";
-    const baseUrl = isPlan ? "plan-estado" : "auditoria-estado";
-    const estadoRevisionJefeId = isPlan
-      ? environment.PLAN_ESTADO.EN_REVISION_JEFE_ID
-      : environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_JEFE;
+    const estadoQuery = [
+          ...this.data.estadoRevisionIds,
+          ...this.data.estadoRechazoIds
+        ].join("|");
 
-    const entityIdQueryName = isPlan ? "plan_auditoria_id" : "auditoria_id";
+    // Construyendo url para solicitud
+    let url = `${this.data.estadoEndpoint}`;
+    // Filtros para obtener tanto rechazos como revisiones del jefe activos
+    url += `?query=${this.data.auditoriaIdReferencia}:${this.data.auditoriaId}` +
+        `,estado_id__in:${estadoQuery}` +
+        ",activo:true";
+    // Obtener todos en una sola página, ordenados por fecha de ejecución descendente
+    url += "&limit=0&sortby=fecha_ejecucion_estado&order=desc";
 
-    const rechazos$ = this.planAuditoriaMid.get(
-      `${baseUrl}?query=${entityIdQueryName}:${auditoriaId},estado_id__in:${estadoQuery},activo:true&limit=0&sortby=fecha_ejecucion_estado&order=desc`
-    );
-
-    const revisionesJefe$ = this.planAuditoriaMid.get(
-      `${baseUrl}?query=${entityIdQueryName}:${auditoriaId},estado_id:${estadoRevisionJefeId},activo:true&limit=0&sortby=fecha_ejecucion_estado&order=desc`
-    );
-
-    forkJoin([rechazos$, revisionesJefe$]).subscribe({
-      next: ([resRechazos, resRevisiones]) => {
-        this.rechazos = resRechazos?.Data ?? [];
-        // Solo mostrar revisiones del jefe que tengan observación no vacía
-        this.revisionesJefe = (resRevisiones?.Data ?? []).filter(
-          (r: any) => r.observacion && r.observacion.trim() !== ""
-        );
+    this.planAuditoriaMid.get(url).subscribe({
+      next: (res) => {
+        const data = res?.Data ?? [];
+        // Sólo mostrar rechazos o revisiones que tengan observación no vacía
+        this.observaciones = data.filter((item: any) =>
+          this.data.estadoRechazoIds.includes(item.estado_id)
+          || item.observacion && item.observacion.trim() !== ""
+        )
         this.cargando = false;
       },
-      error: () => {
-        this.rechazos = [];
-        this.revisionesJefe = [];
+      error: (err) => {
+        console.error("Error al cargar historial de rechazos:", err);
         this.cargando = false;
-      },
+      }
     });
+  }
+
+  isRechazo(observacion: any): boolean {
+    return this.data.estadoRechazoIds.includes(observacion.estado.id);
   }
 }

--- a/src/app/shared/utils/accionesPorRolYEstado.ts
+++ b/src/app/shared/utils/accionesPorRolYEstado.ts
@@ -160,6 +160,7 @@ export const accionesPlaneacion: {
     [environment.AUDITORIA_ESTADO.PLANEACION.REVISION_PROGRAMA_AUDITADO]: [
       "Ver Auditoría",
       "Revisar Auditoría",
+      "Iniciar Ejecución",
       "Historial de Observaciones",
     ],
     [environment.AUDITORIA_ESTADO.PLANEACION.APROBADO_PROGRAMA_AUDITADO]: [

--- a/src/app/shared/utils/accionesPorRolYEstado.ts
+++ b/src/app/shared/utils/accionesPorRolYEstado.ts
@@ -43,16 +43,19 @@ export const accionesProgramacion: {
       "Historial de Observaciones",
     ],
     [environment.PLAN_ESTADO.EN_REVISION_SECRETARIO_ID]: [
-      "Ver Plan",
+      "Ver Documentos",
       "Historial de Observaciones",
     ],
     [environment.PLAN_ESTADO.APROBADO_SECRETARIO_ID]: [
-      "Ver Plan",
+      "Ver Documentos",
       "Historial de Observaciones",
       "Edición Extraordinaria de Auditorías",
       "Historial de Ediciones Extraordinarias",
     ],
-    [environment.PLAN_ESTADO.RECHAZADO]: ["Ver Plan", "Historial de Observaciones"],
+    [environment.PLAN_ESTADO.RECHAZADO]: [
+      "Ver Documentos",
+      "Historial de Observaciones"
+    ],
   },
 
   [environment.ROL.SECRETARIO]: {
@@ -63,10 +66,13 @@ export const accionesProgramacion: {
       "Historial de Observaciones",
     ],
     [environment.PLAN_ESTADO.APROBADO_SECRETARIO_ID]: [
-      "Ver Plan",
+      "Ver Documentos",
       "Historial de Observaciones",
     ],
-    [environment.PLAN_ESTADO.RECHAZADO]: ["Ver Plan", "Historial de Observaciones"],
+    [environment.PLAN_ESTADO.RECHAZADO]: [
+      "Ver Documentos",
+      "Historial de Observaciones"
+    ],
   },
 
   [environment.ROL.AUDITOR_EXPERTO]: {


### PR DESCRIPTION
This pull request introduces several improvements and refactors to how the application handles the display and retrieval of rejection and review histories ("historial de observaciones") for both audit and plan entities. It unifies and simplifies the modal component for showing these histories, updates the data structures and APIs used, and improves the user interface for displaying observations. Additionally, some enhancements were made to notification logic and UI behavior in related components.

- udistrital/sisifo_documentacion#837

The most important changes are:

### Refactoring and Unification of Historial de Observaciones Modal

* Refactored `ModalHistorialRechazosComponent` to use a more unified `HistorialRechazosData` interface, allowing it to handle both audits and plans generically by specifying endpoints, ID references, and state IDs for review and rejection. The modal now fetches all relevant observations in a single request, and the UI logic is simplified to display a unified list of observations. [[1]](diffhunk://#diff-55589af2dca435949de0f598f37be3f0d3a7b07025982e754ecc7699717e5edcL4-R10) [[2]](diffhunk://#diff-55589af2dca435949de0f598f37be3f0d3a7b07025982e754ecc7699717e5edcL22-R22) [[3]](diffhunk://#diff-55589af2dca435949de0f598f37be3f0d3a7b07025982e754ecc7699717e5edcL41-R73)
* Updated the modal's HTML template to use Angular's new block syntax and to display all observations (both rejections and reviews) in a single loop.

### Updates to Modal Usage Across the App

* Updated all usages of the rejection/history modal in audit, plan, and seguimiento tables/components to use the new `HistorialRechazosData` structure, specifying endpoints, ID references, and state arrays for more flexible and accurate data fetching. [[1]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L517-R527) [[2]](diffhunk://#diff-97e211436768ecd00b08f88c08c7f75201c9271265d877d77f6420a2614c7acbL429-R439) [[3]](diffhunk://#diff-88176b34c74b3ad59430940d53964508ef09f7df5d12d633c1398c054cd9e12dL495-R505)
* Updated imports to use the new `HistorialRechazosData` type where necessary. [[1]](diffhunk://#diff-168ee8d0f5ba4ad5452df9e1ccd6700a2295e90cef7451e21b36b1f690ff57a5L14-R14) [[2]](diffhunk://#diff-97e211436768ecd00b08f88c08c7f75201c9271265d877d77f6420a2614c7acbL14-R14) [[3]](diffhunk://#diff-88176b34c74b3ad59430940d53964508ef09f7df5d12d633c1398c054cd9e12dL13-R13)

### Improvements to Notification and Data Handling

* Modified notification logic in `EditarAuditoriaComponent` and `EditarSeguimientoComponent` to fetch and include the "Jefe OCI" user as a recipient for certain notifications. [[1]](diffhunk://#diff-778eacd67fe10f393b5e3d001ec644a39dd3ec32f0bfc0c75130d8af28638409R548-R560) [[2]](diffhunk://#diff-80ac94ee4e612b11dd0332f96f14b5006ac823673288e7eeb7bbf340b979e1d1R480-R492)
* Enhanced the logic in document review components to properly associate complementary emails with dependencies when displaying audit/seguimiento data. [[1]](diffhunk://#diff-2855584c1955ba566c3e1ad7eedbe7e6b0d5474c936e549eb9b80b44a450b5acR782-R787) [[2]](diffhunk://#diff-a31a87152d4e5f1298ef6783881fc5a2ee6548a17b5dddaf7f2e21bd9dec344dR350-R355)

### User Interface and Usability Improvements

* Changed the display of item content in `registrar-plan.component.html` to preserve line breaks, improving readability of multi-line content.
* Updated the document type ID in `modal-aprobacion-secretario.component.ts` to use a value from the environment configuration, improving maintainability.

### Updates to Role-Based Action Configuration

* Updated `accionesPorRolYEstado.ts` to replace "Ver Plan" with "Ver Documentos" for certain plan states, and added "Iniciar Ejecución" as an action for the "REVISION_PROGRAMA_AUDITADO" audit state, reflecting new workflow requirements. [[1]](diffhunk://#diff-0369d1f4f803eb6acea202efcf5b2cb6a63fbf6f49391367843e385848bcd0bbL46-R58) [[2]](diffhunk://#diff-0369d1f4f803eb6acea202efcf5b2cb6a63fbf6f49391367843e385848bcd0bbL66-R75) [[3]](diffhunk://#diff-0369d1f4f803eb6acea202efcf5b2cb6a63fbf6f49391367843e385848bcd0bbR163)