### PR TITLE
feat: permite consulta general de auditorias para el rol auditor experto udistrital/sisifo_documentacion#851

### DIFF
--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/tabla-plan-mejoramiento.component.ts
@@ -93,13 +93,12 @@ export class TablaPlanMejoramientoComponent implements OnInit {
       this.userService.getPersonaId().then((id) => { this.usuarioId = id; });
     } else if (
       this.rolService.tieneRol(environment.ROL.AUDITOR) ||
-      this.rolService.tieneRol(environment.ROL.AUDITOR_ASISTENTE) ||
-      this.rolService.tieneRol(environment.ROL.AUDITOR_EXPERTO)
+      this.rolService.tieneRol(environment.ROL.AUDITOR_ASISTENTE)
     ) {
       this.tipoConsulta = "auditor";
       this.userService.getPersonaId().then((id) => { this.usuarioId = id; });
     } else {
-      // JEFE y otros roles usan endpoint general; igual necesitan usuarioId para registrar estados
+      // JEFE, AUDITOR_EXPERTO y otros roles usan endpoint general
       this.userService.getPersonaId().then((id) => { this.usuarioId = id; });
     }
   }


### PR DESCRIPTION
# Corrección consulta de auditorías para AUDITOR_EXPERTO

## Descripción

Se ajusta la lógica de `configurarTipoConsulta()` para que el rol `AUDITOR_EXPERTO` utilice la consulta general de auditorías en lugar de la consulta filtrada por auditor asignado.

## Cambios realizados

* Se removió `AUDITOR_EXPERTO` de la condición que asigna `tipoConsulta = "auditor"`.
* El rol ahora utiliza la consulta general de auditorías de la vigencia.
* Se garantiza la visualización de auditorías en estado **SIN_PLAN_MEJORAMIENTO**, incluso cuando aún no existen auditores asignados.

## Resultado

* El rol `AUDITOR_EXPERTO` puede visualizar todas las auditorías disponibles en la vigencia.
* Se habilita correctamente la acción **"Asignar Auditor(es)"** para auditorías sin asignaciones previas.
* El comportamiento queda alineado con el módulo de planeación, donde este rol también utiliza la consulta general.

udistrital/sisifo_documentacion#851