### PR TITLE
feat: Regenerar documentos en edición de fase de planeación

### DIFF
--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
@@ -512,7 +512,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
     }
 
     const modalInstance = dialogRef.componentInstance;
-    modalInstance.botonRegenerar = { icono: "refresh", texto: "Regenerar carta actual" };
+    modalInstance.botonRegenerar = { icono: "refresh", texto: "Aplicar cambios" };
     modalInstance.onRegenerarIndividual = async (indice: number): Promise<string> => {
       return await firstValueFrom(
         this.PlanAnualAuditoriaMid
@@ -521,12 +521,12 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
             map((res) => {
               const carta = res.Data.find((carta: any) => carta.dependencia_id === documentos[indice].dependenciaId);
               documentos[indice].base64 = carta.base64;
-              this.alertService.showSuccessAlert(`Carta de ${documentos[indice].dependenciaNombre} regenerada exitosamente. No olvide guardar los cambios para actualizar la carta guardada.`);
+              this.alertService.showSuccessAlert(`Carta de ${documentos[indice].dependenciaNombre} generada exitosamente. No olvide guardar los cambios para actualizar la carta.`);
               return documentos[indice].base64;
             }),
             catchError((error) => {
-              console.error("Error al regenerar el documento", error);
-              this.alertService.showErrorAlert("No fue posible regenerar el documento.");
+              console.error("Error al generar el documento", error);
+              this.alertService.showErrorAlert("No fue posible generar el documento.");
               return of(documentos[indice].base64);
             })
           )
@@ -711,7 +711,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
       const modalInstance = dialogRef.componentInstance;
       modalInstance.botonGuardar = { icono: "save", texto: "Guardar documento" };
 
-      modalInstance.botonRegenerar = { icono: "refresh", texto: "Regenerar documento" };
+      modalInstance.botonRegenerar = { icono: "refresh", texto: "Aplicar cambios" };
       modalInstance.onRegenerarIndividual = async (indice: number): Promise<string> => {
         return await firstValueFrom(
           this.PlanAnualAuditoriaMid
@@ -719,12 +719,12 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
             .pipe(
               map((res) => {
                 documentoBase64 = res.Data;
-                this.alertService.showSuccessAlert(`Documento regenerado exitosamente. No olvide guardar para actualizar el documento guardado.`);
+                this.alertService.showSuccessAlert(`Documento generado exitosamente. No olvide guardar para actualizar el documento.`);
                 return documentoBase64;
               }),
               catchError((error) => {
-                console.error("Error al regenerar el documento", error);
-                this.alertService.showErrorAlert("No fue posible regenerar el documento.");
+                console.error("Error al generar el documento", error);
+                this.alertService.showErrorAlert("No fue posible generar el documento.");
                 return of(documentoBase64);
               })
             )

--- a/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
+++ b/src/app/modules/planeacion/components/auditorias-internas/editar-auditoria/documentos-anexos-auditoria/documentos-anexos-auditoria.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angu
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { ActivatedRoute } from "@angular/router";
-import { Subscription } from "rxjs";
+import { catchError, firstValueFrom, map, of, Subscription } from "rxjs";
 import { NuxeoService } from "src/app/core/services/nuxeo.service";
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
@@ -34,6 +34,7 @@ interface CartaRepresentacionPersistida {
 }
 
 interface DocumentoAdjuntoInicial {
+  _id: string;
   tipo_id: number;
   nuxeo_enlace?: string;
   nombre?: string;
@@ -55,6 +56,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
   idCompromisoEtico: any = null;
   base64CompromisoEtico: any = null;
   documentosExistentes: { [tipoId: number]: string | null } = {};
+  registrosDocExistentes: DocumentoAdjuntoInicial[] = [];
   cartasRepresentacionEsperadas: CartaRepresentacionDocumento[] = [];
   cartasRepresentacionExistentes: CartaRepresentacionPersistida[] = [];
   private routeSubscription: Subscription | null = null;
@@ -150,7 +152,8 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
 
   private async cargarEstadoDocumentos(): Promise<void> {
     try {
-      const documentosAdjuntos = await this.buscarDocumentosAdjuntosIniciales();
+      this.registrosDocExistentes = await this.buscarDocumentosAdjuntosIniciales();
+      const documentosAdjuntos = this.registrosDocExistentes.filter(doc => !!doc.nuxeo_enlace);
       const documentosPorTipo = this.agruparDocumentosPorTipo(documentosAdjuntos);
 
       this.cartasRepresentacionExistentes = [];
@@ -509,8 +512,35 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
     }
 
     const modalInstance = dialogRef.componentInstance;
-    modalInstance.botonGuardar = { icono: "save", texto: "Guardar carta actual" };
-    modalInstance.botonGuardarTodos = { icono: "save", texto: "Guardar todas" };
+    modalInstance.botonRegenerar = { icono: "refresh", texto: "Regenerar carta actual" };
+    modalInstance.onRegenerarIndividual = async (indice: number): Promise<string> => {
+      return await firstValueFrom(
+        this.PlanAnualAuditoriaMid
+          .get(`plantilla/${infoDocumento.plantilla}/${this.auditoriaId}`)
+          .pipe(
+            map((res) => {
+              const carta = res.Data.find((carta: any) => carta.dependencia_id === documentos[indice].dependenciaId);
+              documentos[indice].base64 = carta.base64;
+              this.alertService.showSuccessAlert(`Carta de ${documentos[indice].dependenciaNombre} regenerada exitosamente. No olvide guardar los cambios para actualizar la carta guardada.`);
+              return documentos[indice].base64;
+            }),
+            catchError((error) => {
+              console.error("Error al regenerar el documento", error);
+              this.alertService.showErrorAlert("No fue posible regenerar el documento.");
+              return of(documentos[indice].base64);
+            })
+          )
+      );
+    }
+
+    if (documentos.length > 1) {
+      modalInstance.botonGuardar = { icono: "save", texto: "Guardar carta actual" };
+      modalInstance.botonGuardarTodos = { icono: "save", texto: "Guardar todas" };
+    }
+    else {
+      modalInstance.botonGuardar = { icono: "save", texto: "Guardar carta" };
+    }
+
     modalInstance.botonDescargarDOCX = { icono: "download", texto: "Descargar DOCX"};
     modalInstance.onGuardarIndividual = (indice: number) => {
       this.guardarDocumento(
@@ -569,6 +599,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
               this.auditoriaId,
               info.parametro,
               this.esCartaRepresentacion(info) ? { dependencia_id: info.dependenciaId } : undefined,
+              this.encontrarRegistroDocExistente(info.parametro, info.dependenciaId)?._id,
               () => {
                 if (this.esCartaRepresentacion(info)) {
                   const nombreDependencia = this.normalizarNombreDependencia(
@@ -627,6 +658,16 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
     }
   }
 
+  private encontrarRegistroDocExistente(tipo_id: number, dependencia_id?: number): DocumentoAdjuntoInicial | undefined {
+    if (tipo_id !== environment.TIPO_DOCUMENTO_PARAMETROS.CARTA_PRESENTACION)
+      return this.registrosDocExistentes.find(doc => doc.tipo_id === tipo_id);
+
+    return this.registrosDocExistentes.find(doc =>
+      doc.tipo_id === tipo_id &&
+      doc.metadatos?.["dependencia_id"] === dependencia_id
+    );
+  }
+
   private descargarDocumentoDOCX(base64String: any, nombreDocumento: string) {
 
     const byteCharacters = atob(base64String);
@@ -669,6 +710,26 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
     if (!this.soloLectura) {
       const modalInstance = dialogRef.componentInstance;
       modalInstance.botonGuardar = { icono: "save", texto: "Guardar documento" };
+
+      modalInstance.botonRegenerar = { icono: "refresh", texto: "Regenerar documento" };
+      modalInstance.onRegenerarIndividual = async (indice: number): Promise<string> => {
+        return await firstValueFrom(
+          this.PlanAnualAuditoriaMid
+            .get(`plantilla/${infoDocumento.plantilla}/${this.auditoriaId}`)
+            .pipe(
+              map((res) => {
+                documentoBase64 = res.Data;
+                this.alertService.showSuccessAlert(`Documento regenerado exitosamente. No olvide guardar para actualizar el documento guardado.`);
+                return documentoBase64;
+              }),
+              catchError((error) => {
+                console.error("Error al regenerar el documento", error);
+                this.alertService.showErrorAlert("No fue posible regenerar el documento.");
+                return of(documentoBase64);
+              })
+            )
+        );
+      }
     }
 
     dialogRef.afterClosed().subscribe((res) => {
@@ -717,6 +778,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
             this.esCartaRepresentacion(infoDocumento)
               ? { dependencia_id: infoDocumento.dependenciaId, firmado: false }
               : undefined,
+            this.encontrarRegistroDocExistente(infoDocumento.parametro, infoDocumento.dependenciaId)?._id,
             () => {
               if (this.esCartaRepresentacion(infoDocumento)) {
                 const nombreDependencia = this.normalizarNombreDependencia(
@@ -771,6 +833,7 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
     referencia_id: string,
     tipo_id: number,
     metadatos?: Record<string, any>,
+    documentoIdActualizar?: string,
     onSuccess?: () => void,
     onError?: () => void
   ): void {
@@ -781,10 +844,19 @@ export class DocumentosAnexosAuditoriaComponent implements OnInit, OnDestroy {
           referencia_tipo,
           referencia_id,
           tipo_id,
-          metadatos
+          metadatos,
+          documentoIdActualizar ? true : false,
+          documentoIdActualizar
         )
         .subscribe({
           next: (response) => {
+            const registroDocExistente = this.encontrarRegistroDocExistente(tipo_id, metadatos?.["dependencia_id"]);
+
+            if (!registroDocExistente)
+              this.registrosDocExistentes.push(response);
+            else
+              registroDocExistente.nuxeo_enlace = response.nuxeo_enlace;
+
             onSuccess?.();
           },
           error: (error) => {

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/documentos-anexos-seguimiento/documentos-anexos-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/documentos-anexos-seguimiento/documentos-anexos-seguimiento.component.ts
@@ -285,7 +285,7 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
       const modalInstance = dialogRef.componentInstance;
       modalInstance.botonGuardar = { icono: "save", texto: "Guardar documento" };
 
-      modalInstance.botonRegenerar = { icono: "refresh", texto: "Regenerar documento" };
+      modalInstance.botonRegenerar = { icono: "refresh", texto: "Aplicar cambios" };
       modalInstance.onRegenerarIndividual = async (indice: number): Promise<string> => {
         return await firstValueFrom(
           this.PlanAnualAuditoriaMid
@@ -293,12 +293,12 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
             .pipe(
               map((res) => {
                 documentoBase64 = res.Data;
-                this.alertService.showSuccessAlert(`Documento regenerado exitosamente. No olvide guardar para actualizar el documento guardado.`);
+                this.alertService.showSuccessAlert(`Documento generado exitosamente. No olvide guardar para actualizar el documento.`);
                 return documentoBase64;
               }),
               catchError((error) => {
-                console.error("Error al regenerar el documento", error);
-                this.alertService.showErrorAlert("No fue posible regenerar el documento.");
+                console.error("Error al generar el documento", error);
+                this.alertService.showErrorAlert("No fue posible generar el documento.");
                 return of(documentoBase64);
               })
             )

--- a/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/documentos-anexos-seguimiento/documentos-anexos-seguimiento.component.ts
+++ b/src/app/modules/planeacion/components/seguimiento/editar-seguimiento/documentos-anexos-seguimiento/documentos-anexos-seguimiento.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angu
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { ActivatedRoute } from "@angular/router";
-import { Subscription } from "rxjs";
+import { catchError, firstValueFrom, map, of, Subscription } from "rxjs";
 import { NuxeoService } from "src/app/core/services/nuxeo.service";
 import { PlanAnualAuditoriaMid } from "src/app/core/services/plan-anual-auditoria-mid.service";
 import { PlanAnualAuditoriaService } from "src/app/core/services/plan-anual-auditoria.service";
@@ -12,6 +12,14 @@ import { ModalVerDocumentoComponent } from "src/app/shared/elements/components/d
 import { AlertService } from "src/app/shared/services/alert.service";
 import { environment } from "src/environments/environment";
 import { ModalVisualizarRecargarCompromisoEticoComponent } from "../../../auditorias-internas/editar-auditoria/documentos-anexos-auditoria/modal-visualizar-recargar-compromiso-etico/modal-visualizar-recargar-compromiso-etico.component";
+
+interface DocumentoAdjunto {
+  _id: string;
+  tipo_id: number;
+  nuxeo_enlace?: string;
+  nombre?: string;
+  metadatos?: Record<string, any>;
+}
 
 @Component({
     selector: "app-documentos-anexos-seguimiento",
@@ -26,6 +34,7 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
   auditoriaId: string = "";
   formularioDocumentos: FormGroup;
   idCompromisoEtico: any = null;
+  registrosDocExistentes: DocumentoAdjunto[] = [];
   base64CompromisoEtico: any = null;
   documentosExistentes: { [tipoId: number]: string | null } = {};
   private routeSubscription: Subscription | null = null;
@@ -79,6 +88,7 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
     this.idCompromisoEtico = null;
     this.base64CompromisoEtico = null;
     this.documentosExistentes = {};
+    this.registrosDocExistentes = [];
   }
 
   private async cargarEstadoDocumentos(): Promise<void> {
@@ -100,6 +110,7 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
         .subscribe(
           (res) => {
             if (res?.Data?.length > 0) {
+              this.registrosDocExistentes = res.Data;
               resolve(res.Data[0].nuxeo_enlace);
             } else {
               resolve(null);
@@ -259,6 +270,10 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
     });
   }
 
+  private encontrarRegistroDocExistente(tipo_id: number): DocumentoAdjunto | undefined {
+    return this.registrosDocExistentes.find(doc => doc.tipo_id === tipo_id);
+  }
+
   verDocumento(documentoBase64: any, infoDocumento: any) {
     const dialogRef = this.dialog.open(ModalVerDocumentoComponent, {
       width: "1000px",
@@ -269,6 +284,26 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
     if (!this.soloLectura) {
       const modalInstance = dialogRef.componentInstance;
       modalInstance.botonGuardar = { icono: "save", texto: "Guardar documento" };
+
+      modalInstance.botonRegenerar = { icono: "refresh", texto: "Regenerar documento" };
+      modalInstance.onRegenerarIndividual = async (indice: number): Promise<string> => {
+        return await firstValueFrom(
+          this.PlanAnualAuditoriaMid
+            .get(`plantilla/${infoDocumento.plantilla}/${this.auditoriaId}`)
+            .pipe(
+              map((res) => {
+                documentoBase64 = res.Data;
+                this.alertService.showSuccessAlert(`Documento regenerado exitosamente. No olvide guardar para actualizar el documento guardado.`);
+                return documentoBase64;
+              }),
+              catchError((error) => {
+                console.error("Error al regenerar el documento", error);
+                this.alertService.showErrorAlert("No fue posible regenerar el documento.");
+                return of(documentoBase64);
+              })
+            )
+        );
+      }
     }
 
     dialogRef.afterClosed().subscribe((res) => {
@@ -304,7 +339,8 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
             documentoRefNuxeo,
             "Auditoria",
             this.auditoriaId,
-            infoDocumento.parametro
+            infoDocumento.parametro,
+            this.encontrarRegistroDocExistente(infoDocumento.parametro)?._id
           );
           this.documentosExistentes[infoDocumento.parametro] = documentoRefNuxeo?.res?.Enlace ?? null;
         },
@@ -319,7 +355,8 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
     nuxeoResponse: any,
     referencia_tipo: string,
     referencia_id: string,
-    tipo_id: number
+    tipo_id: number,
+    documentoIdActualizar?: string,
   ): void {
     if (nuxeoResponse.res.Enlace) {
       this.referenciaPdfService
@@ -327,10 +364,20 @@ export class DocumentosAnexosSeguimientoComponent implements OnInit, OnDestroy {
           nuxeoResponse.res,
           referencia_tipo,
           referencia_id,
-          tipo_id
+          tipo_id,
+          {},
+          documentoIdActualizar ? true : false,
+          documentoIdActualizar
         )
         .subscribe({
           next: (response) => {
+            const registroDocExistente = this.encontrarRegistroDocExistente(tipo_id);
+
+            if (!registroDocExistente)
+              this.registrosDocExistentes.push(response);
+            else
+              registroDocExistente.nuxeo_enlace = response.nuxeo_enlace;
+
             this.alertService.showSuccessAlert("Archivo subido exitosamente.");
           },
           error: (error) => {

--- a/src/app/shared/elements/components/dialogs/modal-ver-documento/modal-ver-documento.component.html
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documento/modal-ver-documento.component.html
@@ -72,39 +72,50 @@
     >
     <mat-icon>toll</mat-icon>Regresar
   </button>
+  @if (botonRegenerar.texto) {
+    <button
+      mat-raised-button
+      color="primary"
+      class="my-3"
+      (click)="regenerar()"
+    >
+      <mat-icon>{{ botonRegenerar.icono }}</mat-icon>
+      {{ botonRegenerar.texto }}
+    </button>
+  }
   @if (botonGuardar.texto) {
     <button
       mat-raised-button
       color="primary"
       class="my-3"
       (click)="modoMultiple ? guardarIndividual() : guardar()"
-      >
-      <mat-icon>{{ botonGuardar.icono }}</mat-icon
-        >{{ botonGuardar.texto }}
-      </button>
-    }
+    >
+      <mat-icon>{{ botonGuardar.icono }}</mat-icon>
+      {{ botonGuardar.texto }}
+    </button>
+  }
 
-    @if (modoMultiple && botonGuardarTodos.texto) {
-      <button
-        mat-raised-button
-        color="primary"
-        class="my-3"
-        (click)="guardarTodas()"
-        >
-        <mat-icon>{{ botonGuardarTodos.icono }}</mat-icon
-          >{{ botonGuardarTodos.texto }}
-        </button>
-      }
+  @if (modoMultiple && botonGuardarTodos.texto) {
+    <button
+      mat-raised-button
+      color="primary"
+      class="my-3"
+      (click)="guardarTodas()"
+    >
+    <mat-icon>{{ botonGuardarTodos.icono }}</mat-icon>
+    {{ botonGuardarTodos.texto }}
+    </button>
+  }
 
-      @if (botonDescargarDOCX.texto && validarDescargaDOCX()) {
-        <button
-          mat-raised-button
-          color="primary"
-          class="my-3"
-          (click)="descargarDocumentoDOCX()"
-          >
-          <mat-icon>{{ botonDescargarDOCX.icono }}</mat-icon
-            >{{ botonDescargarDOCX.texto }}
-          </button>
-        }
-      </ng-template>
+  @if (botonDescargarDOCX.texto && validarDescargaDOCX()) {
+    <button
+      mat-raised-button
+      color="primary"
+      class="my-3"
+      (click)="descargarDocumentoDOCX()"
+    >
+    <mat-icon>{{ botonDescargarDOCX.icono }}</mat-icon>
+    {{ botonDescargarDOCX.texto }}
+    </button>
+  }
+</ng-template>

--- a/src/app/shared/elements/components/dialogs/modal-ver-documento/modal-ver-documento.component.ts
+++ b/src/app/shared/elements/components/dialogs/modal-ver-documento/modal-ver-documento.component.ts
@@ -21,6 +21,8 @@ interface ModalDocumentoMultipleData {
     standalone: false
 })
 export class ModalVerDocumentoComponent implements OnInit {
+  @Input() botonRegenerar = { icono: "", texto: "" };
+  @Input() onRegenerarIndividual?: (indice: number) => Promise<string>;
   @Input() botonGuardar = { icono: "", texto: "" };
   @Input() botonGuardarTodos = { icono: "", texto: "" };
   @Input() botonDescargarDOCX = { icono: "", texto: "" };
@@ -101,6 +103,24 @@ export class ModalVerDocumentoComponent implements OnInit {
       accion: "guardarDocumento",
       indice,
     });
+  }
+
+  async regenerar(indice: number = this.indiceSeleccionado): Promise<void> {
+    if (!this.onRegenerarIndividual
+        || (this.modoMultiple && (indice < 0 || indice >= this.documentosMultiples.length)))
+      return;
+
+    const newBase64 = await this.onRegenerarIndividual(indice);
+
+    if (!this.modoMultiple) {
+      this.documentoSrc = new Uint8Array(this.base64ToArrayBuffer(newBase64));
+      console.log("Documento regenerado");
+      return;
+    }
+
+    this.documentosMultiples[indice].base64 = newBase64;
+    this.documentosMultiples[indice].guardado = false;
+    this.seleccionarDocumento(indice);
   }
 
   guardarTodas(): void {


### PR DESCRIPTION
Esta solicitud de extracción añade la opción para regenerar documentos en fase de planeación extendiendo la interfaz del modal para ver documentos con un botón con callback y su respectiva implementación en módulos de planeación.

- udistrital/sisifo_documentacion#873

## Cambios realizados

### Componente js de `modal-ver-documentos`

- Se añadió el miembro insertable `botonRegenerar: {icono: string, texto: string}` que define un ícono y texto para el nuevo botón.
- Se añadió el miembro insertable `onRegenerarIndividual: (indice: numero) => Promise<string>` que define la función que se ejecutará cuando el botón sea presionado y que devuelve la cadena `base64` del documento generado.
- Se añadió la función `async regenerar(indice?: numero): Promise<void>` que ejecuta la función `onRegenerarIndividual` para el índice seleccionado actual.

### Componente html de `modal-ver-documentos`

- Se añadió el botón de regeneración después del botón de cerrar y antes del botón de guardar.

### Componente js de `documentos-anexos-auditoria`

- Se creó el nuevo miembro `registrosDocExistentes` para llevar seguimiento de los id de los documentos (colección de auditoría) asociados a la auditoría junto con su lógica de gestión.
- Se implementó una función para identificar documentos en `registrosDocExistentes` usando parámetro e id de dependencia.
- Se añadió el botón de regeneración al modal que se abre para cartas de representación.
- Se implementó la función callback para para regenerar cartas de representación y almacenarlas según estructuras de memoria existentes.
- Se modificó la construcción del modal de ver cartas de representación para que, si la carta es sólo una, no se renderice el botón "Guardar Todas."
- Se añadió el botón de regeneración al modal que se abre al ver documentos sencillos.
- Se implementó la función callback para para regenerar documetos sencillos y almacenarlos según estructuras de memoria existentes.

### Componente js de `documentos-anexos-seguimiento`

- Se creó el nuevo miembro `registrosDocExistentes` para llevar seguimiento de los id de los documentos (colección de auditoría) asociados a la auditoría junto con su lógica de gestión.
- Se implementó una función para identificar documentos en `registrosDocExistentes` usando parámetro.
- Se añadió el botón de regeneración al modal que se abre al ver documentos sencillos.
- Se implementó la función callback para para regenerar documetos sencillos y almacenarlos según estructuras de memoria existentes.