### PR TITLE
fix: corregir duplicado de soloLectura y casing de Parametro (Id/Nombre) en registrar-plan

### DIFF
--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.html
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.html
@@ -43,8 +43,8 @@
     <mat-form-field appearance="outline" class="col-md-2 col-12">
       <mat-label>Fuente <span class="text-danger">*</span></mat-label>
       <mat-select [(ngModel)]="fuenteSeleccionada" (ngModelChange)="guardarFuente()" [disabled]="soloLectura">
-        @for (f of fuentes; track f.id) {
-          <mat-option [value]="f.id">{{ f.nombre }}</mat-option>
+        @for (f of fuentes; track f.Id) {
+          <mat-option [value]="f.Id">{{ f.Nombre }}</mat-option>
         }
       </mat-select>
     </mat-form-field>

--- a/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.ts
+++ b/src/app/modules/plan-mejoramiento/components/plan-de-mejoramiento/ tabla-plan-mejoramiento/registrar-plan/registrar-plan.component.ts
@@ -30,7 +30,6 @@ export class RegistrarPlanComponent implements OnInit {
   soloLectura = false;
   fuenteSeleccionada: number | null = null;
   fuentes: Parametro[] = [];
-  soloLectura: boolean = false;
 
   /** Estados en los que el plan aún puede editarse (registrar/editar acciones). */
   private readonly estadosEditables: number[] = [


### PR DESCRIPTION
## Resumen
Corrige error de compilación en `RegistrarPlanComponent`

## Cambios
- Elimina la declaración duplicada de `soloLectura` en `registrar-plan.component.ts`.
- Actualiza `registrar-plan.component.html` para usar `f.Id` / `f.Nombre` acorde a la interfaz `Parametro`.


